### PR TITLE
12.11 (Mock Upgrade)

### DIFF
--- a/Parser/FieldWriter/DOTNETWriter.py
+++ b/Parser/FieldWriter/DOTNETWriter.py
@@ -43,6 +43,29 @@ PRIORITIZED_COMPLEX_TYPE_CHILDREN = [
     "orderId" # Special case: schema error if orderId is before amount
 ]
 
+CHILD_ELEMENT_TYPE_OVERRIDES = {
+    # Workaround for echeckType becoming echeckTypeCtx in 12.11, breaking compatibility with 12.10 and older.
+    "vendorCredit": {
+        "accountInfo": "echeckType",
+    },
+    "vendorDebit": {
+        "accountInfo": "echeckType",
+    },
+    "submerchantCredit": {
+        "accountInfo": "echeckType",
+    },
+    "submerchantDebit": {
+        "accountInfo": "echeckType",
+    },
+    "customerCredit": {
+        "accountInfo": "echeckType",
+    },
+    "customerDebit": {
+        "accountInfo": "echeckType",
+    },
+}
+
+
 
 """
 Creates a declaration header.
@@ -219,7 +242,10 @@ class DOTNETWriter(FieldWriter.FieldWriter):
             """
             def writeProperty(childName):
                 child = type.childItems[childName]
-                childType = self.getClassString(child.type, child.maxOccurences)
+                childType = self.getClassString(child.type,child.maxOccurences)
+                if className in CHILD_ELEMENT_TYPE_OVERRIDES.keys():
+                    if childName in CHILD_ELEMENT_TYPE_OVERRIDES[className].keys():
+                        childType = CHILD_ELEMENT_TYPE_OVERRIDES[className][childName]
 
                 # Write the property attributes.
                 generatedLine = ""

--- a/Parser/XSDParser/XSDParser.py
+++ b/Parser/XSDParser/XSDParser.py
@@ -20,6 +20,10 @@ XSD_SIMPLE_TYPE_ENUM_OVERRIDES = {
     "sequenceType": "sequenceTypeEnum", # sequenceType exists as enum and non-enum form
 }
 
+XSD_INHERITANCE_OVERRIDES = {
+    "echeckTypeCtx": "echeckType", # Workaround for echeckType becoming echeckTypeCtx in 12.11, breaking compatibility with 12.10 and older.
+}
+
 
 
 """
@@ -316,7 +320,9 @@ class XSD:
     def processComplexType(self,element,name,type=None):
         # Override the base type.
         extensionElement = self.getChildElementOfName(element,"extension")
-        if extensionElement is not None:
+        if name in XSD_INHERITANCE_OVERRIDES.keys():
+            type = XSD_INHERITANCE_OVERRIDES[name]
+        elif extensionElement is not None:
             type = removeSchemaInformation(extensionElement.attrib["base"])
         else:
             extensionElement = self.getChildElementOfName(element,"restriction")

--- a/xsd/SchemaCombined_v12.11.xsd
+++ b/xsd/SchemaCombined_v12.11.xsd
@@ -1,0 +1,4727 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xp="http://www.vantivcnp.com/schema"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+    <!--cnpCommon-->
+
+    <xs:element name="authentication">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="user" type="xp:string20Type" />
+                <xs:element name="password" type="xp:string20Type" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="string20Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="20" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="versionType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="10" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="messageType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="512" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="string2Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="2" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="string3Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="3" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="responseType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="3" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="string4Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="4" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="stringExactly4Type">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="4" />
+            <xs:maxLength value="4" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cnpIdType">
+        <xs:restriction base="xs:long">
+            <xs:totalDigits value="19" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="string25Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="25" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="string36Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="36" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="string50Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="50" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="string80Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="80" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="string128Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="128" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="string256Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="256" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="string512Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="512" />
+        </xs:restriction>
+    </xs:simpleType>
+
+
+    <xs:simpleType name="networkMessageValue">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="9999" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="stringMin1Max36CollapseWhiteSpaceType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1" />
+            <xs:maxLength value="36" />
+            <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cardNumberLast4Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="4" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="virtualAuthenticationKeyData">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="4" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="virtualAuthenticationKeyPresenceIndicator">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="1" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="authorizationSourcePlatform">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="1" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="addressIndicator">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="1" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="authenticationResultType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="1" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="methodOfPaymentTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="MC" />
+            <xs:enumeration value="VI" />
+            <xs:enumeration value="AX" />
+            <xs:enumeration value="DC" />
+            <xs:enumeration value="DI" />
+            <xs:enumeration value="PP" />
+            <xs:enumeration value="JC" />
+            <xs:enumeration value="EC" />
+            <xs:enumeration value="GC" />
+            <xs:enumeration value="" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="actionTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="A" />
+            <xs:enumeration value="D" />
+            <xs:enumeration value="R" />
+            <xs:enumeration value="AR" />
+            <xs:enumeration value="G" />
+            <xs:enumeration value="I" />
+            <xs:enumeration value="J" />
+            <xs:enumeration value="L" />
+            <xs:enumeration value="LR" />
+            <xs:enumeration value="P" />
+            <xs:enumeration value="RR" />
+            <xs:enumeration value="S" />
+            <xs:enumeration value="T" />
+            <xs:enumeration value="UR" />
+            <xs:enumeration value="V" />
+            <xs:enumeration value="W" />
+            <xs:enumeration value="X" />
+            <xs:enumeration value="" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="govtTaxTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="payment" />
+            <xs:enumeration value="fee" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="transactionAmountType">
+        <xs:restriction base="xs:integer">
+            <xs:totalDigits value="12" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="loanToValueEstimator">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="8" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="riskEstimator">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="8" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="riskQueueAssignment">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="8" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="merchantIdentificationType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="50" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="currencyCodeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="AUD" />
+            <xs:enumeration value="CAD" />
+            <xs:enumeration value="CHF" />
+            <xs:enumeration value="DKK" />
+            <xs:enumeration value="EUR" />
+            <xs:enumeration value="GBP" />
+            <xs:enumeration value="HKD" />
+            <xs:enumeration value="JPY" />
+            <xs:enumeration value="NOK" />
+            <xs:enumeration value="NZD" />
+            <xs:enumeration value="SEK" />
+            <xs:enumeration value="SGD" />
+            <xs:enumeration value="USD" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="countryTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="USA" />
+            <xs:enumeration value="AF" />
+            <xs:enumeration value="AX" />
+            <xs:enumeration value="AL" />
+            <xs:enumeration value="DZ" />
+            <xs:enumeration value="AS" />
+            <xs:enumeration value="AD" />
+            <xs:enumeration value="AO" />
+            <xs:enumeration value="AI" />
+            <xs:enumeration value="AQ" />
+            <xs:enumeration value="AG" />
+            <xs:enumeration value="AR" />
+            <xs:enumeration value="AM" />
+            <xs:enumeration value="AW" />
+            <xs:enumeration value="AU" />
+            <xs:enumeration value="AT" />
+            <xs:enumeration value="AZ" />
+            <xs:enumeration value="BS" />
+            <xs:enumeration value="BH" />
+            <xs:enumeration value="BD" />
+            <xs:enumeration value="BB" />
+            <xs:enumeration value="BY" />
+            <xs:enumeration value="BE" />
+            <xs:enumeration value="BZ" />
+            <xs:enumeration value="BJ" />
+            <xs:enumeration value="BM" />
+            <xs:enumeration value="BT" />
+            <xs:enumeration value="BO" />
+            <xs:enumeration value="BQ" />
+            <xs:enumeration value="BA" />
+            <xs:enumeration value="BW" />
+            <xs:enumeration value="BV" />
+            <xs:enumeration value="BR" />
+            <xs:enumeration value="IO" />
+            <xs:enumeration value="BN" />
+            <xs:enumeration value="BG" />
+            <xs:enumeration value="BF" />
+            <xs:enumeration value="BI" />
+            <xs:enumeration value="KH" />
+            <xs:enumeration value="CM" />
+            <xs:enumeration value="CA" />
+            <xs:enumeration value="CV" />
+            <xs:enumeration value="KY" />
+            <xs:enumeration value="CF" />
+            <xs:enumeration value="TD" />
+            <xs:enumeration value="CL" />
+            <xs:enumeration value="CN" />
+            <xs:enumeration value="CX" />
+            <xs:enumeration value="CC" />
+            <xs:enumeration value="CO" />
+            <xs:enumeration value="KM" />
+            <xs:enumeration value="CG" />
+            <xs:enumeration value="CD" />
+            <xs:enumeration value="CK" />
+            <xs:enumeration value="CR" />
+            <xs:enumeration value="CI" />
+            <xs:enumeration value="HR" />
+            <xs:enumeration value="CU" />
+            <xs:enumeration value="CW" />
+            <xs:enumeration value="CY" />
+            <xs:enumeration value="CZ" />
+            <xs:enumeration value="DK" />
+            <xs:enumeration value="DJ" />
+            <xs:enumeration value="DM" />
+            <xs:enumeration value="DO" />
+            <xs:enumeration value="TL" />
+            <xs:enumeration value="EC" />
+            <xs:enumeration value="EG" />
+            <xs:enumeration value="SV" />
+            <xs:enumeration value="GQ" />
+            <xs:enumeration value="ER" />
+            <xs:enumeration value="EE" />
+            <xs:enumeration value="ET" />
+            <xs:enumeration value="FK" />
+            <xs:enumeration value="FO" />
+            <xs:enumeration value="FJ" />
+            <xs:enumeration value="FI" />
+            <xs:enumeration value="FR" />
+            <xs:enumeration value="GF" />
+            <xs:enumeration value="PF" />
+            <xs:enumeration value="TF" />
+            <xs:enumeration value="GA" />
+            <xs:enumeration value="GM" />
+            <xs:enumeration value="GE" />
+            <xs:enumeration value="DE" />
+            <xs:enumeration value="GH" />
+            <xs:enumeration value="GI" />
+            <xs:enumeration value="GR" />
+            <xs:enumeration value="GL" />
+            <xs:enumeration value="GD" />
+            <xs:enumeration value="GP" />
+            <xs:enumeration value="GU" />
+            <xs:enumeration value="GT" />
+            <xs:enumeration value="GG" />
+            <xs:enumeration value="GN" />
+            <xs:enumeration value="GW" />
+            <xs:enumeration value="GY" />
+            <xs:enumeration value="HT" />
+            <xs:enumeration value="HM" />
+            <xs:enumeration value="HN" />
+            <xs:enumeration value="HK" />
+            <xs:enumeration value="HU" />
+            <xs:enumeration value="IS" />
+            <xs:enumeration value="IN" />
+            <xs:enumeration value="ID" />
+            <xs:enumeration value="IR" />
+            <xs:enumeration value="IQ" />
+            <xs:enumeration value="IE" />
+            <xs:enumeration value="IM" />
+            <xs:enumeration value="IL" />
+            <xs:enumeration value="IT" />
+            <xs:enumeration value="JM" />
+            <xs:enumeration value="JP" />
+            <xs:enumeration value="JE" />
+            <xs:enumeration value="JO" />
+            <xs:enumeration value="KZ" />
+            <xs:enumeration value="KE" />
+            <xs:enumeration value="KI" />
+            <xs:enumeration value="KP" />
+            <xs:enumeration value="KR" />
+            <xs:enumeration value="KW" />
+            <xs:enumeration value="KG" />
+            <xs:enumeration value="LA" />
+            <xs:enumeration value="LV" />
+            <xs:enumeration value="LB" />
+            <xs:enumeration value="LS" />
+            <xs:enumeration value="LR" />
+            <xs:enumeration value="LY" />
+            <xs:enumeration value="LI" />
+            <xs:enumeration value="LT" />
+            <xs:enumeration value="LU" />
+            <xs:enumeration value="MO" />
+            <xs:enumeration value="MK" />
+            <xs:enumeration value="MG" />
+            <xs:enumeration value="MW" />
+            <xs:enumeration value="MY" />
+            <xs:enumeration value="MV" />
+            <xs:enumeration value="ML" />
+            <xs:enumeration value="MT" />
+            <xs:enumeration value="MH" />
+            <xs:enumeration value="MQ" />
+            <xs:enumeration value="MR" />
+            <xs:enumeration value="MU" />
+            <xs:enumeration value="YT" />
+            <xs:enumeration value="MX" />
+            <xs:enumeration value="FM" />
+            <xs:enumeration value="MD" />
+            <xs:enumeration value="MC" />
+            <xs:enumeration value="MN" />
+            <xs:enumeration value="MS" />
+            <xs:enumeration value="MA" />
+            <xs:enumeration value="MZ" />
+            <xs:enumeration value="MM" />
+            <xs:enumeration value="NA" />
+            <xs:enumeration value="NR" />
+            <xs:enumeration value="NP" />
+            <xs:enumeration value="NL" />
+            <xs:enumeration value="AN" />
+            <xs:enumeration value="NC" />
+            <xs:enumeration value="NZ" />
+            <xs:enumeration value="NI" />
+            <xs:enumeration value="NE" />
+            <xs:enumeration value="NG" />
+            <xs:enumeration value="NU" />
+            <xs:enumeration value="NF" />
+            <xs:enumeration value="MP" />
+            <xs:enumeration value="NO" />
+            <xs:enumeration value="OM" />
+            <xs:enumeration value="PK" />
+            <xs:enumeration value="PW" />
+            <xs:enumeration value="PS" />
+            <xs:enumeration value="PA" />
+            <xs:enumeration value="PG" />
+            <xs:enumeration value="PY" />
+            <xs:enumeration value="PE" />
+            <xs:enumeration value="PH" />
+            <xs:enumeration value="PN" />
+            <xs:enumeration value="PL" />
+            <xs:enumeration value="PT" />
+            <xs:enumeration value="PR" />
+            <xs:enumeration value="QA" />
+            <xs:enumeration value="RE" />
+            <xs:enumeration value="RO" />
+            <xs:enumeration value="RU" />
+            <xs:enumeration value="RW" />
+            <xs:enumeration value="BL" />
+            <xs:enumeration value="KN" />
+            <xs:enumeration value="LC" />
+            <xs:enumeration value="MF" />
+            <xs:enumeration value="VC" />
+            <xs:enumeration value="WS" />
+            <xs:enumeration value="SM" />
+            <xs:enumeration value="ST" />
+            <xs:enumeration value="SA" />
+            <xs:enumeration value="SN" />
+            <xs:enumeration value="SC" />
+            <xs:enumeration value="SL" />
+            <xs:enumeration value="SG" />
+            <xs:enumeration value="SX" />
+            <xs:enumeration value="SK" />
+            <xs:enumeration value="SI" />
+            <xs:enumeration value="SB" />
+            <xs:enumeration value="SO" />
+            <xs:enumeration value="ZA" />
+            <xs:enumeration value="GS" />
+            <xs:enumeration value="ES" />
+            <xs:enumeration value="LK" />
+            <xs:enumeration value="SH" />
+            <xs:enumeration value="PM" />
+            <xs:enumeration value="SD" />
+            <xs:enumeration value="SR" />
+            <xs:enumeration value="SJ" />
+            <xs:enumeration value="SZ" />
+            <xs:enumeration value="SE" />
+            <xs:enumeration value="CH" />
+            <xs:enumeration value="SY" />
+            <xs:enumeration value="TW" />
+            <xs:enumeration value="TJ" />
+            <xs:enumeration value="TZ" />
+            <xs:enumeration value="TH" />
+            <xs:enumeration value="TG" />
+            <xs:enumeration value="TK" />
+            <xs:enumeration value="TO" />
+            <xs:enumeration value="TT" />
+            <xs:enumeration value="TN" />
+            <xs:enumeration value="TR" />
+            <xs:enumeration value="TM" />
+            <xs:enumeration value="TC" />
+            <xs:enumeration value="TV" />
+            <xs:enumeration value="UG" />
+            <xs:enumeration value="UA" />
+            <xs:enumeration value="AE" />
+            <xs:enumeration value="GB" />
+            <xs:enumeration value="US" />
+            <xs:enumeration value="UM" />
+            <xs:enumeration value="UY" />
+            <xs:enumeration value="UZ" />
+            <xs:enumeration value="VU" />
+            <xs:enumeration value="VA" />
+            <xs:enumeration value="VE" />
+            <xs:enumeration value="VN" />
+            <xs:enumeration value="VG" />
+            <xs:enumeration value="VI" />
+            <xs:enumeration value="WF" />
+            <xs:enumeration value="EH" />
+            <xs:enumeration value="YE" />
+            <xs:enumeration value="ZM" />
+            <xs:enumeration value="ZW" />
+            <xs:enumeration value="RS" />
+            <xs:enumeration value="ME" />
+            <xs:enumeration value="SS" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="addressLineType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="35" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="cityType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="35" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="customBillingCityType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="35" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="stateType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="30" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="zipType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="20" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="emailType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="100" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="phoneType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="20" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="nameType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="100" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="cvNumType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="4" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="authCodeType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="6" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="customerIdType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="50" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="customBillingUrlType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="13" />
+            <xs:pattern value="[A-Z,a-z,0-9,/,\-,_,.]*"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="IIASFlagType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="1"/>
+            <xs:enumeration value="Y"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="driversLicenseType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="30" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="stateCodeType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="2" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="dateOfBirthType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="8" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="firstNameType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="25" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="lastNameType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="25" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="middleInitialType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="1" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="companyName">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="40" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="redeliveryCycle">
+        <xs:restriction base="xs:integer">
+            <xs:totalDigits value="1" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="numberOfDeposits">
+        <xs:restriction base="xs:integer">
+            <xs:totalDigits value="1" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="contact">
+        <xs:all>
+            <xs:element name="name" type="xp:nameType" minOccurs="0" />
+            <xs:element name="firstName" type="xp:firstNameType" minOccurs="0" />
+            <xs:element name="middleInitial" type="xp:middleInitialType" minOccurs="0" />
+            <xs:element name="lastName" type="xp:lastNameType" minOccurs="0" />
+            <xs:element name="companyName" type="xp:companyName" minOccurs="0" />
+            <xs:element name="addressLine1" type="xp:addressLineType" minOccurs="0" />
+            <xs:element name="addressLine2" type="xp:addressLineType" minOccurs="0" />
+            <xs:element name="addressLine3" type="xp:addressLineType" minOccurs="0" />
+            <xs:element name="city" type="xp:cityType" minOccurs="0" />
+            <xs:element name="state" type="xp:stateType" minOccurs="0" />
+            <xs:element name="zip" type="xp:zipType" minOccurs="0" />
+            <xs:element name="country" type="xp:countryTypeEnum" minOccurs="0" />
+            <xs:element name="email" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="xp:emailType">
+                        <xs:maxLength value="100" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="phone" type="xp:phoneType" minOccurs="0" />
+        </xs:all>
+    </xs:complexType>
+
+    <xs:element name="billToAddress" type="xp:contact" />
+
+    <xs:complexType name="mposType">
+        <xs:sequence>
+            <xs:element name = "ksn" type="xp:ksnType" />
+            <xs:element name = "formatId" type="xp:formatIdType" />
+            <xs:element name = "encryptedTrack" type="xp:encryptedTrackType" />
+            <xs:element name = "track1Status" type="xp:trackStatusType" />
+            <xs:element name = "track2Status" type="xp:trackStatusType" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="cardType">
+        <xs:sequence>
+            <xs:choice>
+                <xs:sequence>
+                    <xs:element name="type" type="xp:methodOfPaymentTypeEnum" />
+                    <xs:element name="number" type="xp:ccAccountNumberType" minOccurs="0"/>
+                    <xs:element name="expDate" type="xp:expDateType" minOccurs="0" />
+                </xs:sequence>
+                <xs:sequence>
+                    <xs:element name="track" type="xp:trackDataType" />
+                </xs:sequence>
+            </xs:choice>
+            <xs:element name="cardValidationNum" type="xp:cvNumType" minOccurs="0" />
+            <xs:element name="pin" type="xp:pinType" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="giftCardCardType">
+        <xs:complexContent>
+            <xs:restriction base="xp:cardType">
+                <xs:sequence>
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="type" type="xp:methodOfPaymentTypeEnum" fixed="GC"/>
+                            <xs:element name="number" type="xp:ccAccountNumberType" minOccurs="0"/>
+                            <xs:element name="expDate" type="xp:expDateType" minOccurs="0" />
+                        </xs:sequence>
+                        <xs:sequence>
+                            <xs:element name="track" type="xp:trackDataType" />
+                        </xs:sequence>
+                    </xs:choice>
+                    <xs:element name="cardValidationNum" type="xp:cvNumType" minOccurs="0" />
+                    <xs:element name="pin" type="xp:pinType" minOccurs="0" />
+                </xs:sequence>
+            </xs:restriction>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:simpleType name="pinType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="4"/>
+            <xs:maxLength value="12" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="cardTokenType">
+        <xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="1">
+                <xs:element name="cnpToken" type="xp:ccAccountNumberType"/>
+                <xs:element name="tokenURL" type="xp:awpTokenUrlType"/>
+            </xs:choice>
+            <xs:element name="expDate" type="xp:expDateType" minOccurs="0" />
+            <xs:element name="cardValidationNum" type="xp:cvNumType" minOccurs="0" />
+            <xs:element name="type" type="xp:methodOfPaymentTypeEnum" minOccurs="0" />
+            <xs:element name="checkoutId" type="xp:checkoutIdType" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="checkoutIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="18" />
+            <xs:maxLength value="18" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="cardPaypageType">
+        <xs:sequence>
+            <xs:element name="paypageRegistrationId" type="xp:string512Type"/>
+            <xs:element name="expDate" type="xp:expDateType" minOccurs="0" />
+            <xs:element name="cardValidationNum" type="xp:cvNumType" minOccurs="0" />
+            <xs:element name="type" type="xp:methodOfPaymentTypeEnum" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="tokenResponseType">
+        <xs:sequence>
+            <xs:element name="cnpToken" type="xp:ccAccountNumberType" minOccurs="0"/>
+            <xs:element name="tokenResponseCode" type="xp:responseType"/>
+            <xs:element name="tokenMessage" type="xs:string"/>
+            <xs:element name="type" type="xp:methodOfPaymentTypeEnum" minOccurs="0"/>
+            <xs:element name="bin" type="xs:string" minOccurs="0"/>
+            <xs:element name="eCheckAccountSuffix" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="ksnType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="1028" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="formatIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="1028" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="encryptedTrackType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="1028" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="encryptedCcAccountNumberType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="1028" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="trackStatusType">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="1028"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="ccAccountNumberType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="13" />
+            <xs:maxLength value="25" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="expDateType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="4" />
+            <xs:maxLength value="4" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="trackDataType">
+        <xs:restriction base="xs:string">
+            <xs:whiteSpace value="collapse" />
+            <xs:minLength value="1" />
+            <xs:maxLength value="256" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="awpTokenUrlType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="http.?://.*/.*"/>
+            <xs:maxLength value="400"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="advancedFraudChecksType">
+        <xs:sequence>
+            <xs:element name="threatMetrixSessionId" type="xp:threatMetrixSessionIdType" minOccurs="0"/>
+            <xs:element name="webSessionId" type="xp:webSessionIdType" minOccurs="0"/>
+            <xs:element name="customAttribute1" type="xp:customAttributeType" minOccurs="0"/>
+            <xs:element name="customAttribute2" type="xp:customAttributeType" minOccurs="0"/>
+            <xs:element name="customAttribute3" type="xp:customAttributeType" minOccurs="0"/>
+            <xs:element name="customAttribute4" type="xp:customAttributeType" minOccurs="0"/>
+            <xs:element name="customAttribute5" type="xp:customAttributeType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="threatMetrixSessionIdType">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="[-a-zA-Z0-9_]{1,128}" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="webSessionIdType">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="[-a-zA-Z0-9_]{1,128}" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="advancedFraudResultsType">
+        <xs:sequence>
+            <xs:element name="deviceReviewStatus" type="xs:string" minOccurs="0"/>
+            <xs:element name="deviceReputationScore" type="xs:int" minOccurs="0"/>
+            <xs:element name="triggeredRule" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="customAttributeType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="200" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="string15Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="15" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="string30Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="30" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="stringExactly16AlphanumericType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z,a-z,0-9]{16,16}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="lodgingDurationType">
+        <xs:restriction base="xs:integer">
+            <xs:totalDigits value="4" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="csPhoneType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="17" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="noOfAdultsType">
+        <xs:restriction base="xs:integer">
+            <xs:totalDigits value="2" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="lodgingExtraChargeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="RESTAURANT" />
+            <xs:enumeration value="GIFTSHOP" />
+            <xs:enumeration value="MINIBAR" />
+            <xs:enumeration value="TELEPHONE" />
+            <xs:enumeration value="OTHER" />
+            <xs:enumeration value="LAUNDRY" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="lodgingCharge">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="name" type="xp:lodgingExtraChargeEnum" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="lodgingProgramCodeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="LODGING" />
+            <xs:enumeration value="NOSHOW" />
+            <xs:enumeration value="ADVANCEDDEPOSIT" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="yesNoType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Y" />
+            <xs:enumeration value="N" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!--cnpRecurring-->
+
+    <xs:element name="recurringTransaction" type="xp:recurringTransactionType" abstract="true" />
+    <xs:element name="recurringTransactionResponse" type="xp:recurringTransactionResponseType" abstract="true" />
+    <xs:complexType name="cnpTransactionInterface" abstract="true"/>
+
+    <xs:complexType name="recurringTransactionType">
+        <xs:complexContent>
+            <xs:extension base="xp:cnpTransactionInterface">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="recurringTransactionResponseType">
+        <xs:complexContent>
+            <xs:extension base="xp:cnpTransactionInterface">
+                <xs:sequence>
+                    <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                    <xs:element name="response" type="xp:responseType" />
+                    <xs:element name="message" type="xs:string" />
+                    <xs:element name="responseTime" type="xs:dateTime" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:element name="cancelSubscription" substitutionGroup="xp:recurringTransaction" >
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:recurringTransactionType">
+                    <xs:sequence>
+                        <xs:element name="subscriptionId" type="xp:cnpIdType" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="updateSubscription" substitutionGroup="xp:recurringTransaction" >
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:recurringTransactionType">
+                    <xs:sequence>
+                        <xs:element name="subscriptionId" type="xp:cnpIdType" />
+                        <xs:element name="planCode" type="xp:string25Type" minOccurs="0" />
+                        <xs:element ref="xp:billToAddress" minOccurs="0" />
+                        <xs:choice minOccurs="0">
+                            <xs:element name="card" type="xp:cardType" />
+                            <xs:element name="token" type="xp:cardTokenType" />
+                            <xs:element name="paypage" type="xp:cardPaypageType" />
+                        </xs:choice>
+                        <xs:element name="billingDate" type="xs:date" minOccurs="0"/>
+                        <xs:element name="createDiscount" type="xp:createDiscountType" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="updateDiscount" type="xp:updateDiscountType" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="deleteDiscount" type="xp:deleteDiscountType" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="createAddOn" type="xp:createAddOnType" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="updateAddOn" type="xp:updateAddOnType" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="deleteAddOn" type="xp:deleteAddOnType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="createPlan" substitutionGroup="xp:recurringTransaction" >
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:recurringTransactionType">
+                    <xs:sequence>
+                        <xs:element name="planCode" type="xp:string25Type"/>
+                        <xs:element name="name" type="xp:nameType"/>
+                        <xs:element name="description" type="xp:nameType" minOccurs="0"/>
+                        <xs:element name="intervalType" type="xp:intervalTypeEnum"/>
+                        <xs:element name="amount" type="xp:transactionAmountType"/>
+                        <xs:element name="numberOfPayments" type="xp:numberOfPaymentsType" minOccurs="0"/>
+                        <xs:element name="trialNumberOfIntervals" type="xp:numberOfPaymentsType" minOccurs="0"/>
+                        <xs:element name="trialIntervalType" type="xp:trialIntervalTypeEnum" minOccurs="0"/>
+                        <xs:element name="active" type="xs:boolean" minOccurs="0"/>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="updatePlan" substitutionGroup="xp:recurringTransaction" >
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:recurringTransactionType">
+                    <xs:sequence>
+                        <xs:element name="planCode" type="xp:string25Type" />
+                        <xs:element name="active" type="xs:boolean" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="cancelSubscriptionResponse" substitutionGroup="xp:recurringTransactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:recurringTransactionResponseType">
+                    <xs:sequence>
+                        <xs:element name="subscriptionId" type="xp:cnpIdType" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="updateSubscriptionResponse" substitutionGroup="xp:recurringTransactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:recurringTransactionResponseType">
+                    <xs:sequence>
+                        <xs:element name="subscriptionId" type="xp:cnpIdType" />
+                        <xs:element name="tokenResponse" type="xp:tokenResponseType" minOccurs="0"/>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="createPlanResponse" substitutionGroup="xp:recurringTransactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:recurringTransactionResponseType">
+                    <xs:sequence>
+                        <xs:element name="planCode" type="xp:string25Type"/>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="updatePlanResponse" substitutionGroup="xp:recurringTransactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:recurringTransactionResponseType">
+                    <xs:sequence>
+                        <xs:element name="planCode" type="xp:string25Type"/>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <!--Recurring Types -->
+    <xs:complexType name="recurringSubscriptionType">
+        <xs:sequence>
+            <xs:element name="planCode" type="xp:string25Type" />
+            <xs:element name="numberOfPayments" type="xp:numberOfPaymentsType" minOccurs="0"/>
+            <xs:element name="startDate" type="xs:date" minOccurs="0"/>
+            <xs:element name="amount" type="xp:transactionAmountType" minOccurs="0"/>
+            <xs:element name="createDiscount" type="xp:createDiscountType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="createAddOn" type="xp:createAddOnType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="numberOfPaymentsType">
+        <xs:restriction base="xs:integer">
+            <xs:minInclusive value="1" />
+            <xs:maxInclusive value="99" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="intervalTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ANNUAL" />
+            <xs:enumeration value="SEMIANNUAL" />
+            <xs:enumeration value="QUARTERLY" />
+            <xs:enumeration value="MONTHLY" />
+            <xs:enumeration value="WEEKLY" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="trialIntervalTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="MONTH" />
+            <xs:enumeration value="DAY" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="cnpInternalRecurringRequestType">
+        <xs:sequence>
+            <xs:element name="subscriptionId" type="xp:cnpIdType" />
+            <xs:element name="recurringTxnId" type="xp:cnpIdType" />
+            <xs:element name="finalPayment" type="xs:boolean" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="recurringRequestType">
+        <xs:sequence>
+            <xs:element name="createSubscription" type="xp:recurringSubscriptionType" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="recurringResponseType">
+        <xs:sequence>
+            <xs:element name="subscriptionId" type="xp:cnpIdType" />
+            <xs:element name="responseCode" type="xp:responseType" />
+            <xs:element name="responseMessage" type="xp:messageType" />
+            <xs:element name="recurringTxnId" type="xp:cnpIdType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="createDiscountType">
+        <xs:sequence>
+            <xs:element name="discountCode" type="xp:string25Type" />
+            <xs:element name="name" type="xp:nameType" />
+            <xs:element name="amount" type="xp:transactionAmountType" />
+            <xs:element name="startDate" type="xs:date" />
+            <xs:element name="endDate" type="xs:date" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="updateDiscountType">
+        <xs:sequence>
+            <xs:element name="discountCode" type="xp:string25Type" />
+            <xs:element name="name" type="xp:nameType" minOccurs="0"/>
+            <xs:element name="amount" type="xp:transactionAmountType" minOccurs="0"/>
+            <xs:element name="startDate" type="xs:date" minOccurs="0"/>
+            <xs:element name="endDate" type="xs:date" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="deleteDiscountType">
+        <xs:sequence>
+            <xs:element name="discountCode" type="xp:string25Type" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="createAddOnType">
+        <xs:sequence>
+            <xs:element name="addOnCode" type="xp:string25Type" />
+            <xs:element name="name" type="xp:nameType" />
+            <xs:element name="amount" type="xp:transactionAmountType" />
+            <xs:element name="startDate" type="xs:date" />
+            <xs:element name="endDate" type="xs:date" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="updateAddOnType">
+        <xs:sequence>
+            <xs:element name="addOnCode" type="xp:string25Type" />
+            <xs:element name="name" type="xp:nameType" minOccurs="0"/>
+            <xs:element name="amount" type="xp:transactionAmountType" minOccurs="0"/>
+            <xs:element name="startDate" type="xs:date" minOccurs="0"/>
+            <xs:element name="endDate" type="xs:date" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="deleteAddOnType">
+        <xs:sequence>
+            <xs:element name="addOnCode" type="xp:string25Type" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <!--cnpTransaction-->
+
+    <xs:element name="transaction" type="xp:transactionType" abstract="true" />
+
+    <xs:complexType name="transactionType">
+        <xs:complexContent>
+            <xs:extension base="xp:cnpTransactionInterface">
+                <xs:attribute name="id" type="xp:stringMin1Max36CollapseWhiteSpaceType" use="required" />
+                <xs:attribute name="customerId" type="xp:customerIdType" use="optional" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="transactionTypeWithReportGroup">
+        <xs:complexContent>
+            <xs:extension base="xp:transactionType">
+                <xs:attribute name="reportGroup" type="xp:reportGroupType" use="required" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="merchantDataType">
+        <xs:all>
+            <xs:element name="campaign" type="xp:campaignType" minOccurs="0" />
+            <xs:element name="affiliate" type="xp:affiliateType" minOccurs="0" />
+            <xs:element name="merchantGroupingId" type="xp:merchantGroupingIdType" minOccurs="0" />
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="transactionTypeWithReportGroupAndPartial">
+        <xs:complexContent>
+            <xs:extension base="xp:transactionType">
+                <xs:attribute name="reportGroup" type="xp:reportGroupType" use="required" />
+                <xs:attribute name="partial" type="xs:boolean" use="optional" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="transactionTypeOptionReportGroup">
+        <xs:complexContent>
+            <xs:extension base="xp:transactionType">
+                <xs:attribute name="reportGroup" type="xp:reportGroupType" use="optional" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="driversLicenseInfo">
+        <xs:all>
+            <xs:element name="licenseNumber" type="xp:driversLicenseType" />
+            <xs:element name="state" type="xp:stateCodeType"  minOccurs="0" />
+            <xs:element name="dateOfBirth" type="xp:dateOfBirthType"  minOccurs="0" />
+        </xs:all>
+    </xs:complexType>
+
+    <xs:element name="customerInfo">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="ssn" minOccurs="0">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:pattern value="(\d{5})?\d{4}" />
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="dob" type="xs:date" minOccurs="0" />
+                <xs:element name="customerRegistrationDate" type="xs:date" minOccurs="0" />
+                <xs:element name="customerType" minOccurs="0">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="New" />
+                            <xs:enumeration value="Existing" />
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="incomeAmount" type="xs:long" minOccurs="0" />
+                <xs:element name="incomeCurrency" type="xp:currencyCodeEnum" default="USD" minOccurs="0" />
+                <xs:element name="customerCheckingAccount" type="xs:boolean" minOccurs="0" />
+                <xs:element name="customerSavingAccount" type="xs:boolean" minOccurs="0" />
+                <xs:element name="employerName" type="xp:string20Type" minOccurs="0" />
+                <xs:element name="customerWorkTelephone" type="xp:phoneType" minOccurs="0" />
+                <xs:element name="residenceStatus" minOccurs="0">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="Own" />
+                            <xs:enumeration value="Rent" />
+                            <xs:enumeration value="Other" />
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="yearsAtResidence" minOccurs="0">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:int">
+                            <xs:totalDigits value="2" />
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="yearsAtEmployer" minOccurs="0">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:int">
+                            <xs:totalDigits value="2" />
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="fraudCheckType">
+        <xs:all>
+            <xs:element name="authenticationValue" type="xp:authenticationValueType" minOccurs="0" />
+            <xs:element name="authenticationTransactionId" type="xp:authenticationTransactionIdType" minOccurs="0" />
+            <xs:element name="customerIpAddress" type="xp:ipAddress" minOccurs="0" />
+            <xs:element name="authenticatedByMerchant" type="xs:boolean" minOccurs="0" />
+            <xs:element name="authenticationProtocolVersion" type="xp:authenticationProtocolVersionType" minOccurs="0" />
+        </xs:all>
+    </xs:complexType>
+
+    <xs:element name="authorization" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        </xs:sequence>
+                        <xs:sequence>
+                            <xs:element name="orderId" type="xp:string25Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
+                            <xs:element name="surchargeAmount" type="xp:transactionAmountType" minOccurs="0" />
+                            <xs:element name="orderSource" type="xp:orderSourceType" />
+                            <xs:element ref="xp:customerInfo" minOccurs="0" />
+                            <xs:element ref="xp:billToAddress" minOccurs="0" />
+                            <xs:element ref="xp:shipToAddress" minOccurs="0" />
+                            <xs:choice>
+                                <xs:element name="mpos" type="xp:mposType" />
+                                <xs:element name="card" type="xp:cardType" />
+                                <xs:element name="paypal" type="xp:payPal" />
+                                <xs:element name="token" type="xp:cardTokenType" />
+                                <xs:element name="paypage" type="xp:cardPaypageType" />
+                                <xs:element name="applepay" type="xp:applepayType" />
+                            </xs:choice>
+                            <xs:element name="cardholderAuthentication" type="xp:fraudCheckType" minOccurs="0" />
+                            <xs:element ref="xp:processingInstructions" minOccurs="0" />
+                            <xs:element ref="xp:pos" minOccurs="0" />
+                            <xs:element ref="xp:customBilling" minOccurs="0" />
+                            <xs:element name="taxType" type="xp:govtTaxTypeEnum" minOccurs="0" />
+                            <xs:element ref="xp:enhancedData" minOccurs="0" />
+                            <xs:element name="allowPartialAuth" type="xs:boolean" minOccurs="0" />
+                            <xs:element ref="xp:healthcareIIAS" minOccurs="0" />
+                            <xs:element ref="xp:lodgingInfo" minOccurs="0" />
+                            <xs:element name="filtering" type="xp:filteringType" minOccurs="0"/>
+                            <xs:element name="merchantData" type="xp:merchantDataType" minOccurs="0" />
+                            <xs:element name="recyclingRequest" type="xp:recyclingRequestType" minOccurs="0"/>
+                            <xs:element name="fraudFilterOverride" type="xs:boolean" minOccurs="0"/>
+                            <xs:element name="recurringRequest" type="xp:recurringRequestType" minOccurs="0"/>
+                            <xs:element name="debtRepayment" type="xs:boolean" minOccurs="0" />
+                            <xs:element name="advancedFraudChecks" type="xp:advancedFraudChecksType" minOccurs="0"/>
+                            <xs:element ref="xp:wallet" minOccurs="0" />
+                            <xs:element name="processingType" type="xp:processingTypeEnum" minOccurs="0" />
+                            <xs:element name="originalNetworkTransactionId" type="xp:string30Type" minOccurs="0" />
+                            <xs:element name="originalTransactionAmount" type="xp:transactionAmountType" minOccurs="0" />
+                            <xs:element name="pinlessDebitRequest" type="xp:pinlessDebitRequestType" minOccurs="0"/>
+                            <xs:element name="skipRealtimeAU" type="xs:boolean" minOccurs="0" />
+                            <xs:element name="merchantCategoryCode" type="xp:stringExactly4Type" minOccurs="0" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="authReversal" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="amount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element name="surchargeAmount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element name="payPalNotes" type="xp:payPalNotesType" minOccurs="0" />
+                        <xs:element name="actionReason" type="xp:actionReasonType" minOccurs="0" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="giftCardAuthReversal" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" minOccurs="0" />
+                        <xs:element name="card" type="xp:giftCardCardType" />
+                        <xs:element name="originalRefCode" type="xp:authCodeType" />
+                        <xs:element name="originalAmount" type="xp:transactionAmountType" />
+                        <xs:element name="originalTxnTime" type="xs:dateTime" />
+                        <xs:element name="originalSystemTraceId" type="xp:systemTraceType" />
+                        <xs:element name="originalSequenceNumber" type="xp:sequenceType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="capture" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroupAndPartial">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="amount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element name="surchargeAmount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element ref="xp:enhancedData" minOccurs="0" />
+                        <xs:element ref="xp:processingInstructions" minOccurs="0" />
+                        <xs:element name="payPalOrderComplete" type="xs:boolean" minOccurs="0" />
+                        <xs:element name="payPalNotes" type="xp:payPalNotesType" minOccurs="0" />
+                        <xs:element ref="xp:customBilling" minOccurs="0" />
+                        <xs:element ref="xp:lodgingInfo" minOccurs="0" />
+                        <xs:element name="pin" type="xp:pinType" minOccurs="0" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="giftCardCapture" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroupAndPartial">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" minOccurs="0" />
+                        <xs:element name="captureAmount" type="xp:transactionAmountType"/>
+                        <xs:element name="card" type="xp:giftCardCardType" />
+                        <xs:element name="originalRefCode" type="xp:authCodeType" />
+                        <xs:element name="originalAmount" type="xp:transactionAmountType" />
+                        <xs:element name="originalTxnTime" type="xs:dateTime" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="forceCapture" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="amount" type="xp:transactionAmountType" />
+                        <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element name="surchargeAmount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element name="orderSource" type="xp:orderSourceType" />
+                        <xs:element ref="xp:billToAddress" minOccurs="0" />
+                        <xs:choice>
+                                <xs:element name="mpos" type="xp:mposType" />
+                                <xs:element name="card" type="xp:cardType" />
+                                <xs:element name="token" type="xp:cardTokenType" />
+                                <xs:element name="paypage" type="xp:cardPaypageType" />
+                        </xs:choice>
+                        <xs:element ref="xp:customBilling" minOccurs="0" />
+                        <xs:element name="taxType" type="xp:govtTaxTypeEnum" minOccurs="0" />
+                        <xs:element ref="xp:enhancedData" minOccurs="0" />
+                        <xs:element ref="xp:lodgingInfo" minOccurs="0" />
+                        <xs:element ref="xp:processingInstructions" minOccurs="0" />
+                        <xs:element ref="xp:pos" minOccurs="0" />
+                        <xs:element name="merchantData" type="xp:merchantDataType" minOccurs="0" />
+                        <xs:element name="debtRepayment" type="xs:boolean" minOccurs="0" />
+                        <xs:element name="processingType" type="xp:processingTypeEnum" minOccurs="0" />
+                        <xs:element name="merchantCategoryCode" type="xp:stringExactly4Type" minOccurs="0" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="captureGivenAuth" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element ref="xp:authInformation" />
+                        <xs:element name="amount" type="xp:transactionAmountType" />
+                        <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element name="surchargeAmount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element name="orderSource" type="xp:orderSourceType" />
+                        <xs:element ref="xp:billToAddress" minOccurs="0" />
+                        <xs:element ref="xp:shipToAddress" minOccurs="0" />
+                        <xs:choice>
+                                <xs:element name="mpos" type="xp:mposType" />
+                                <xs:element name="card" type="xp:cardType" />
+                                <xs:element name="token" type="xp:cardTokenType" />
+                                <xs:element name="paypage" type="xp:cardPaypageType" />
+                        </xs:choice>
+                        <xs:element ref="xp:customBilling" minOccurs="0" />
+                        <xs:element name="taxType" type="xp:govtTaxTypeEnum" minOccurs="0" />
+                        <xs:element ref="xp:enhancedData" minOccurs="0" />
+                        <xs:element ref="xp:lodgingInfo" minOccurs="0" />
+                        <xs:element ref="xp:processingInstructions" minOccurs="0" />
+                        <xs:element ref="xp:pos" minOccurs="0" />
+                        <xs:element name="merchantData" type="xp:merchantDataType" minOccurs="0" />
+                        <xs:element name="debtRepayment" type="xs:boolean" minOccurs="0" />
+                        <xs:element name="processingType" type="xp:processingTypeEnum" minOccurs="0" />
+                        <xs:element name="originalNetworkTransactionId" type="xp:string30Type" minOccurs="0" />
+                        <xs:element name="originalTransactionAmount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element name="merchantCategoryCode" type="xp:stringExactly4Type" minOccurs="0" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="sale" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <!-- This element was missing from the 6.2 online version but in the 6.2 online castor mapping.  Batch version used here for consistence -->
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" minOccurs="0" />
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="amount" type="xp:transactionAmountType" />
+                        <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element name="surchargeAmount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element name="orderSource" type="xp:orderSourceType" />
+                        <xs:element ref="xp:customerInfo" minOccurs="0" />
+                        <xs:element ref="xp:billToAddress" minOccurs="0" />
+                        <xs:element ref="xp:shipToAddress" minOccurs="0" />
+                        <xs:choice>
+                            <xs:element name="mpos" type="xp:mposType" />
+                            <xs:element name="card" type="xp:cardType" />
+                            <xs:element name="paypal" type="xp:payPal" />
+                            <xs:element name="token" type="xp:cardTokenType" />
+                            <xs:element name="paypage" type="xp:cardPaypageType" />
+                            <xs:element name="applepay" type="xp:applepayType" />
+                            <xs:element name="sepaDirectDebit" type="xp:sepaDirectDebitType" />
+                            <xs:element name="ideal" type="xp:idealType" />
+                            <xs:element name="giropay" type="xp:giropayType" />
+                            <xs:element name="sofort" type="xp:sofortType" />
+                        </xs:choice>
+                        <!-- fraudCheck is not used in the mapping -->
+
+                        <xs:choice>
+                            <xs:element name="fraudCheck" type="xp:fraudCheckType" minOccurs="0" />
+                            <xs:element name="cardholderAuthentication" type="xp:fraudCheckType" minOccurs="0" />
+                        </xs:choice>
+                        <xs:element ref="xp:customBilling" minOccurs="0" />
+                        <xs:element name="taxType" type="xp:govtTaxTypeEnum" minOccurs="0" />
+                        <xs:element ref="xp:enhancedData" minOccurs="0" />
+                        <xs:element ref="xp:processingInstructions" minOccurs="0" />
+                        <xs:element ref="xp:pos" minOccurs="0" />
+                        <xs:element name="payPalOrderComplete" type="xs:boolean" minOccurs="0" />
+                        <xs:element name="payPalNotes" type="xp:payPalNotesType" minOccurs="0" />
+                        <xs:element name="allowPartialAuth" type="xs:boolean" minOccurs="0" />
+                        <xs:element ref="xp:healthcareIIAS" minOccurs="0" />
+                        <xs:element ref="xp:lodgingInfo" minOccurs="0" />
+                        <xs:element name="filtering" type="xp:filteringType" minOccurs="0"/>
+                        <xs:element name="merchantData" type="xp:merchantDataType" minOccurs="0" />
+                        <xs:element name="recyclingRequest" type="xp:recyclingRequestType" minOccurs="0"/>
+                        <xs:element name="fraudFilterOverride" type="xs:boolean" minOccurs="0"/>
+                        <xs:element name="recurringRequest" type="xp:recurringRequestType" minOccurs="0"/>
+                        <xs:element name="cnpInternalRecurringRequest" type="xp:cnpInternalRecurringRequestType" minOccurs="0"/>
+                        <xs:element name="debtRepayment" type="xs:boolean" minOccurs="0" />
+                        <xs:element name="advancedFraudChecks" type="xp:advancedFraudChecksType" minOccurs="0"/>
+                        <xs:element ref="xp:wallet" minOccurs="0" />
+                        <xs:element name="processingType" type="xp:processingTypeEnum" minOccurs="0" />
+                        <xs:element name="originalNetworkTransactionId" type="xp:string30Type" minOccurs="0" />
+                        <xs:element name="originalTransactionAmount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element name="pinlessDebitRequest" type="xp:pinlessDebitRequestType" minOccurs="0"/>
+                        <xs:element name="skipRealtimeAU" type="xs:boolean" minOccurs="0" />
+                        <xs:element name="merchantCategoryCode" type="xp:stringExactly4Type" minOccurs="0" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- Online credit txn -->
+    <xs:element name="credit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:choice>
+                            <xs:sequence>
+                                <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                                <xs:element name="amount" type="xp:transactionAmountType" minOccurs="0" />
+                                <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
+                                <xs:element name="surchargeAmount" type="xp:transactionAmountType" minOccurs="0" />
+                                <xs:element ref="xp:customBilling" minOccurs="0" />
+                                <xs:element ref="xp:enhancedData" minOccurs="0" />
+                                <xs:element ref="xp:lodgingInfo" minOccurs="0" />
+                                <xs:element ref="xp:processingInstructions" minOccurs="0" />
+                                <xs:element ref="xp:pos" minOccurs="0" />
+                                <xs:element name="pin" type="xp:pinType" minOccurs="0" />
+                            </xs:sequence>
+                            <xs:sequence>
+                                <xs:element name="orderId" type="xp:string25Type" />
+                                <xs:element name="amount" type="xp:transactionAmountType" />
+                                <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
+                                <xs:element name="surchargeAmount" type="xp:transactionAmountType" minOccurs="0" />
+                                <xs:element name="orderSource" type="xp:orderSourceType" />
+                                <xs:element ref="xp:billToAddress" minOccurs="0" />
+                                <xs:choice>
+                                    <xs:element name="mpos" type="xp:mposType" />
+                                    <xs:element name="card" type="xp:cardType" />
+                                    <xs:element name="token" type="xp:cardTokenType" />
+                                    <xs:element name="paypage" type="xp:cardPaypageType" />
+                                    <xs:element name="paypal">
+                                        <xs:complexType>
+                                            <xs:choice>
+                                                <xs:element name="payerId" minOccurs="1">
+                                                    <xs:simpleType>
+                                                        <xs:restriction base="xs:string">
+                                                            <xs:whiteSpace value="collapse" />
+                                                            <xs:minLength value="1" />
+                                                            <xs:maxLength value="17" />
+                                                        </xs:restriction>
+                                                    </xs:simpleType>
+                                                </xs:element>
+                                                <xs:element name="payerEmail" minOccurs="1">
+                                                    <xs:simpleType>
+                                                        <xs:restriction base="xs:string">
+                                                            <xs:whiteSpace value="collapse" />
+                                                            <xs:minLength value="1" />
+                                                            <xs:maxLength value="127" />
+                                                        </xs:restriction>
+                                                    </xs:simpleType>
+                                                </xs:element>
+                                            </xs:choice>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:choice>
+                                <xs:element ref="xp:customBilling" minOccurs="0" />
+                                <xs:element name="taxType" type="xp:govtTaxTypeEnum" minOccurs="0" />
+                                <xs:element ref="xp:enhancedData" minOccurs="0" />
+                                <xs:element ref="xp:lodgingInfo" minOccurs="0" />
+                                <xs:element ref="xp:processingInstructions" minOccurs="0" />
+                                <xs:element ref="xp:pos" minOccurs="0" />
+                                <xs:element name="merchantData" type="xp:merchantDataType" minOccurs="0" />
+                                <xs:element name="merchantCategoryCode" type="xp:stringExactly4Type" minOccurs="0" />
+                            </xs:sequence>
+                        </xs:choice>
+                        <xs:element name="payPalNotes" type="xp:payPalNotesType" minOccurs="0" />
+                        <xs:element name="actionReason" type="xp:actionReasonType" minOccurs="0" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="giftCardCredit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:choice>
+                            <xs:sequence>
+                                <xs:element name="cnpTxnId" type="xp:cnpIdType" minOccurs="0"/>
+                                <xs:element name="creditAmount" type="xp:transactionAmountType" />
+                                <xs:element name="card" type="xp:giftCardCardType" />
+                            </xs:sequence>
+                            <xs:sequence>
+                                <xs:element name="orderId" type="xp:string25Type" />
+                                <xs:element name="creditAmount" type="xp:transactionAmountType" />
+                                <xs:element name="orderSource" type="xp:orderSourceType" />
+                                <xs:element name="card" type="xp:giftCardCardType" />
+                            </xs:sequence>
+                        </xs:choice>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="activate" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="amount" type="xp:transactionAmountType" minOccurs="1" />
+                        <xs:element name="orderSource" type="xp:orderSourceType" />
+                        <xs:choice>
+                            <xs:element name="card" type="xp:giftCardCardType"/>
+                            <xs:element name="virtualGiftCard" type="xp:virtualGiftCardType"/>
+                        </xs:choice>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="deactivate" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderSource" type="xp:orderSourceType" />
+                        <xs:element name="card" type="xp:giftCardCardType" minOccurs="1" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="load" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="amount" type="xp:transactionAmountType" minOccurs="1" />
+                        <xs:element name="orderSource" type="xp:orderSourceType" />
+                        <xs:element name="card" type="xp:giftCardCardType" minOccurs="1" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="unload" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="amount" type="xp:transactionAmountType" minOccurs="1" />
+                        <xs:element name="orderSource" type="xp:orderSourceType" />
+                        <xs:element name="card" type="xp:giftCardCardType" minOccurs="1" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="shipToAddress" type="xp:contact" />
+
+    <xs:element name="authInformation">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="authDate" type="xs:date" />
+                <xs:element name="authCode" type="xp:authCodeType" />
+                <xs:element ref="xp:fraudResult" minOccurs="0" />
+                <xs:element name="authAmount" type="xp:transactionAmountType" minOccurs="0" />
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="balanceInquiry" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderSource" type="xp:orderSourceType" />
+                        <xs:element name="card" type="xp:giftCardCardType" minOccurs="1" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="healthcareIIAS">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="xp:healthcareAmounts" minOccurs="1"/>
+                <xs:element name="IIASFlag" type="xp:IIASFlagType" minOccurs="1"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="healthcareAmounts">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="totalHealthcareAmount" type="xp:transactionAmountType" minOccurs="1"/>
+                <xs:element name="RxAmount" type="xp:transactionAmountType" minOccurs="0"/>
+                <xs:element name="visionAmount" type="xp:transactionAmountType" minOccurs="0"/>
+                <xs:element name="clinicOtherAmount" type="xp:transactionAmountType" minOccurs="0"/>
+                <xs:element name="dentalAmount" type="xp:transactionAmountType" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="enhancedData">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="customerReference" type="xp:customerReferenceType" minOccurs="0" />
+                <xs:element name="salesTax" type="xp:transactionAmountType" minOccurs="0" />
+                <xs:element name="deliveryType" minOccurs="0" default="TBD">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="CNC" />
+                            <xs:enumeration value="DIG" />
+                            <xs:enumeration value="PHY" />
+                            <xs:enumeration value="SVC" />
+                            <xs:enumeration value="TBD" />
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="taxExempt" type="xs:boolean" minOccurs="0" />
+                <xs:element name="discountAmount" type="xp:transactionAmountType" minOccurs="0" />
+                <xs:element name="shippingAmount" type="xp:transactionAmountType" minOccurs="0" />
+                <xs:element name="dutyAmount" type="xp:transactionAmountType" minOccurs="0" />
+                <xs:element name="shipFromPostalCode" type="xp:zipType" minOccurs="0" />
+                <xs:element name="destinationPostalCode" type="xp:zipType" minOccurs="0" />
+                <xs:element name="destinationCountryCode" type="xp:countryTypeEnum" minOccurs="0" />
+                <xs:element name="invoiceReferenceNumber" type="xp:invoiceReferenceNumberType" minOccurs="0" />
+                <xs:element name="orderDate" type="xs:date" minOccurs="0" />
+                <xs:element ref="xp:detailTax" minOccurs="0" maxOccurs="6" />
+                <xs:element ref="xp:lineItemData" minOccurs="0" maxOccurs="99" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="detailTax">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="taxIncludedInTotal" type="xs:boolean" minOccurs="0" />
+                <xs:element name="taxAmount" type="xp:transactionAmountType" />
+                <xs:element name="taxRate" type="xp:taxRateType" minOccurs="0" />
+                <xs:element name="taxTypeIdentifier" type="xp:taxTypeIdentifierEnum" minOccurs="0" />
+                <xs:element name="cardAcceptorTaxId" type="xp:cardAcceptorTaxIdType" minOccurs="0" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="lineItemData">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="itemSequenceNumber" type="xp:itemSequenceNumberType" minOccurs="0" />
+                <xs:element name="itemDescription" type="xp:itemDescriptionType" />
+                <xs:element name="productCode" type="xp:productCodeType" minOccurs="0" />
+                <xs:element name="quantity" type="xp:quantityType" minOccurs="0" />
+                <xs:element name="unitOfMeasure" type="xp:unitOfMeasureType" minOccurs="0" />
+                <xs:element name="taxAmount" type="xp:transactionAmountType" minOccurs="0" />
+                <xs:element name="lineItemTotal" type="xp:transactionAmountType" minOccurs="0" />
+                <!-- quantity * unit cost -->
+                <xs:element name="lineItemTotalWithTax" type="xp:transactionAmountType" minOccurs="0" />
+                <!-- line item total + tax -->
+                <xs:element name="itemDiscountAmount" type="xp:transactionAmountType" minOccurs="0" />
+                <xs:element name="commodityCode" type="xp:commodityCodeType" minOccurs="0" />
+                <xs:element name="unitCost" type="xp:unitCostType" minOccurs="0" />
+                <xs:element ref="xp:detailTax" minOccurs="0" maxOccurs="6" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="accountInfoType">
+        <xs:sequence>
+            <xs:element name="type" type="xp:methodOfPaymentTypeEnum" />
+            <xs:element name="number" type="xp:ccAccountNumberType" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="echeckTokenType">
+        <xs:sequence>
+            <xs:element name="cnpToken" type="xp:ccAccountNumberType"/>
+            <xs:element name="routingNum" type="xp:routingNumberType" />
+            <xs:element name="accType" type="xp:echeckAccountTypeEnum" />
+            <xs:element name="checkNum" type="xp:checkNumberType" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="payPal">
+        <xs:sequence>
+            <xs:element name="payerId" type="xs:string" minOccurs="1" />
+            <xs:element name="token" type="xs:string" minOccurs="0" />
+            <xs:element name="transactionId" type="xs:string" minOccurs="1" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="payPalNotesType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="255" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="actionReasonType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="255" />
+            <!-- <xs:enumeration value="UNKNOWN" />
+            <xs:enumeration value="SUSPECT_FRAUD" /> -->
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="customBilling">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:choice>
+                    <xs:element name="phone" type="xp:customBillingPhoneType" minOccurs="0" />
+                    <xs:element name="city" type="xp:customBillingCityType" minOccurs="0" />
+                    <xs:element name="url" type="xp:customBillingUrlType" minOccurs="0" />
+                </xs:choice>
+                <xs:element name="descriptor" type="xp:descriptorType" minOccurs="0" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="taxTypeIdentifierEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="00" /><!-- Unknown -->
+            <xs:enumeration value="01" /><!-- Federal/National Sales Tax -->
+            <xs:enumeration value="02" /><!-- State Sales Tax -->
+            <xs:enumeration value="03" /><!-- City Sales Tax -->
+            <xs:enumeration value="04" /><!-- Local Sales Tax -->
+            <xs:enumeration value="05" /><!-- Municipal Sales Tax -->
+            <xs:enumeration value="06" /><!-- Other Tax -->
+            <xs:enumeration value="10" /><!-- Value Added Tax (VAT) -->
+            <xs:enumeration value="11" /><!-- Goods and Services Tax (GST) -->
+            <xs:enumeration value="12" /><!-- Provincial Sales Tax (PST) -->
+            <xs:enumeration value="13" /><!-- Harmonized Sales Tax (HST) -->
+            <xs:enumeration value="14" /><!-- Quebec Sales Tax (QST) -->
+            <xs:enumeration value="20" /><!-- Room Tax -->
+            <xs:enumeration value="21" /><!-- Occupancy Tax -->
+            <xs:enumeration value="22" /><!-- Energy Tax -->
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="processingInstructions">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="bypassVelocityCheck" type="xs:boolean" minOccurs="0" />
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="pos">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="capability" type="xp:posCapabilityTypeEnum" />
+                <xs:element name="entryMode" type="xp:posEntryModeTypeEnum" />
+                <xs:element name="cardholderId" type="xp:posCardholderIdTypeEnum" />
+                <xs:element name="terminalId" type="xs:string" minOccurs="0"/>
+                <xs:element name="catLevel" type="xp:posCatLevelEnum" minOccurs="0"/>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="registerTokenRequest" substitutionGroup="xp:transaction" type="xp:registerTokenRequestType"/>
+
+    <xs:complexType name="registerTokenRequestType">
+        <xs:complexContent>
+            <xs:extension base="xp:transactionTypeWithReportGroup">
+                <xs:sequence>
+                    <xs:element name="encryptionKeyId" type="xp:string25Type" minOccurs="0" />
+                    <xs:element name="orderId" type="xp:string25Type" minOccurs="0" />
+                    <xs:choice>
+                        <xs:element name="mpos" type="xp:mposType" />
+                        <xs:element name="accountNumber" type="xp:ccAccountNumberType" />
+                        <xs:element name="encryptedAccountNumber" type="xp:encryptedCcAccountNumberType" />
+                        <xs:element name="echeckForToken" type="xp:echeckForTokenType" />
+                        <xs:element name="paypageRegistrationId" type="xp:string512Type" />
+                        <xs:element name="applepay" type="xp:applepayType" />
+                    </xs:choice>
+                    <xs:choice>
+                        <xs:element name="cardValidationNum" type="xp:cvNumType" minOccurs="0" />
+                        <xs:element name="encryptedCardValidationNum" type="xp:encryptedCcAccountNumberType" minOccurs="0" />
+                    </xs:choice>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:element name="registerTokenResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="cnpToken" type="xp:ccAccountNumberType" minOccurs="0"/>
+                        <xs:element name="bin" type="xs:string" minOccurs="0"/>
+                        <xs:element name="type" type="xp:methodOfPaymentTypeEnum" minOccurs="0"/>
+                        <xs:element name="eCheckAccountSuffix" type="xs:string" minOccurs="0"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="message" type="xs:string"/>
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element ref="xp:applepayResponse" minOccurs="0"/>
+                        <xs:element ref="xp:androidpayResponse" minOccurs="0"/>
+                        <xs:element name="accountRangeId" type="xp:cnpIdType" minOccurs="0" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+
+    <xs:element name="transactionResponse" type="xp:transactionTypeWithReportGroup" abstract="true" />
+
+    <xs:element name="authorizationResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="cardProductId" type="xs:string" minOccurs="0" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element name="authCode" type="xp:authCodeType" minOccurs="0" />
+                        <xs:element name="authorizationResponseSubCode" type="xs:string" minOccurs="0" />
+                        <xs:element name="approvedAmount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element name="accountInformation" minOccurs="0" type="xp:accountInfoType" />
+                        <xs:element ref="xp:accountUpdater" minOccurs="0" />
+                        <xs:element ref="xp:fraudResult" minOccurs="0" />
+                        <!-- if tokenized merchant -->
+                        <xs:element name="tokenResponse" type="xp:tokenResponseType" minOccurs="0"/>
+                        <xs:element ref="xp:enhancedAuthResponse" minOccurs="0" />
+                        <xs:element name="recyclingResponse" type="xp:recyclingResponseType" minOccurs="0"/>
+                        <xs:element name="recurringResponse" type="xp:recurringResponseType" minOccurs="0"/>
+                        <!-- If Gift card transaction -->
+                        <xs:element ref="xp:giftCardResponse" minOccurs="0"/>
+                        <xs:element ref="xp:applepayResponse" minOccurs="0"/>
+                        <xs:element name="cardSuffix" type="xp:cardSuffixType" minOccurs="0" />
+                        <xs:element ref="xp:androidpayResponse" minOccurs="0"/>
+                        <!-- For merchant initiated transactions -->
+                        <xs:element name="networkTransactionId" type="xp:string30Type" minOccurs="0" />
+                        <xs:element name="paymentAccountReferenceNumber" type="xp:string50Type" minOccurs="0" />
+                        <xs:element ref="xp:pinlessDebitResponse" minOccurs="0"/>
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="fundingSourceTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="UNKNOWN" />
+            <xs:enumeration value="PREPAID" />
+            <xs:enumeration value="FSA" />
+            <xs:enumeration value="CREDIT" />
+            <xs:enumeration value="DEBIT" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="affluenceTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="AFFLUENT" />
+            <xs:enumeration value="MASS AFFLUENT" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="reloadablePrepaidTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="UNKNOWN" />
+            <xs:enumeration value="YES" />
+            <xs:enumeration value="NO" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cardSuffixType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="3" />
+            <xs:maxLength value="6" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cardProductTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="UNKNOWN" />
+            <xs:enumeration value="COMMERCIAL" />
+            <xs:enumeration value="CONSUMER" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="recycleAdviceType">
+        <xs:choice>
+            <xs:element name="nextRecycleTime" type="xs:dateTime" />
+            <xs:element name="recycleAdviceEnd" type="xp:string20Type" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:simpleType name="recycleByTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Merchant" />
+            <xs:enumeration value="Cnp" />
+            <xs:enumeration value="None" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="accountUpdateSourceType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="R" />
+            <xs:enumeration value="N" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="recyclingResponseType">
+        <xs:sequence>
+            <xs:element name="recycleAdvice" type="xp:recycleAdviceType" minOccurs="0"/>
+            <xs:element name="recycleEngineActive" type="xs:boolean" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="networkSubField" >
+        <xs:sequence>
+            <xs:element name="fieldValue" type="xp:networkMessageValue" minOccurs="1" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="fieldNumber" type="xs:integer" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="networkFieldNameEnumType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Transaction Amount" />
+            <xs:enumeration value="Settlement Amount" />
+            <xs:enumeration value="Cardholder Billing Amount" />
+            <xs:enumeration value="Settlement Conversion Rate" />
+            <xs:enumeration value="Cardholder Billing Conversion Rate" />
+            <xs:enumeration value="Settlement Date" />
+            <xs:enumeration value="Authorization Identification Response" />
+            <xs:enumeration value="Response Code" />
+            <xs:enumeration value="Additional Response Data" />
+            <xs:enumeration value="Private Use Additional Data" />
+            <xs:enumeration value="Settlement Currency Code" />
+            <xs:enumeration value="Cardholder Billing Currency Code" />
+            <xs:enumeration value="Additional Amounts" />
+            <xs:enumeration value="Reserved Private" />
+            <xs:enumeration value="Transaction Description" />
+            <xs:enumeration value="Reserved for National Use" />
+            <xs:enumeration value="Reserved for Private Use" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="networkField">
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="fieldValue" type="xp:networkMessageValue" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="networkSubField" type="xp:networkSubField" maxOccurs="unbounded" minOccurs="0" />
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="fieldNumber" type="xs:integer" use="required"/>
+        <xs:attribute name="fieldName" type="xp:networkFieldNameEnumType" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="networkResponse">
+        <xs:sequence>
+            <xs:element name="endpoint" type="xp:string256Type" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="networkField" type="xp:networkField" maxOccurs="unbounded" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="recyclingRequestType">
+        <xs:sequence>
+            <xs:element name="recycleBy" type="xp:recycleByTypeEnum" minOccurs="0"/>
+            <xs:element name="recycleId" type="xp:string25Type" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="enhancedAuthResponse">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="fundingSource" minOccurs="0" >
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="type" type="xp:fundingSourceTypeEnum"/>
+                            <xs:element name="availableBalance" type="xp:string20Type"/>
+                            <xs:element name="reloadable" type="xp:string50Type" minOccurs="0" />
+                            <xs:element name="prepaidCardType" type="xp:string50Type" minOccurs="0"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="affluence" type="xp:affluenceTypeEnum" minOccurs="0" />
+                <xs:element name="issuerCountry" type="xp:string3Type" minOccurs="0" />
+                <xs:element name="cardProductType" type="xp:cardProductTypeEnum" minOccurs="0" />
+                <xs:element name="virtualAccountNumber" type="xs:boolean" minOccurs="0" />
+                <xs:element name="networkResponse" type="xp:networkResponse" minOccurs="0" maxOccurs="1" />
+                <xs:element name="accountRangeId" type="xp:cnpIdType" minOccurs="0" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="authReversalResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- postDate is online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="giftCardAuthReversalResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- postDate is online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element ref="xp:giftCardResponse" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="depositReversalResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- postDate is online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <!-- If Gift card transaction -->
+                        <xs:element ref="xp:giftCardResponse" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="refundReversalResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- postDate is online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <!-- If Gift card transaction -->
+                        <xs:element ref="xp:giftCardResponse" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="activateReversalResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- postDate is online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <!-- If Gift card transaction -->
+                        <xs:element ref="xp:giftCardResponse" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="deactivateReversalResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- postDate is online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <!-- If Gift card transaction -->
+                        <xs:element ref="xp:giftCardResponse" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="loadReversalResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- postDate is online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <!-- If Gift card transaction -->
+                        <xs:element ref="xp:giftCardResponse" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="unloadReversalResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- postDate is online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <!-- If Gift card transaction -->
+                        <xs:element ref="xp:giftCardResponse" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="captureResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <!-- batch only -->
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- postDate is online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element ref="xp:accountUpdater" minOccurs="0" />
+                        <!-- If Gift Card transaction -->
+                        <xs:element ref="xp:fraudResult" minOccurs="0" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="giftCardCaptureResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <!-- batch only -->
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- postDate is online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element ref="xp:fraudResult" minOccurs="0" />
+                        <xs:element ref="xp:giftCardResponse" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="forceCaptureResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <!-- if tokenenized merchant -->
+                        <xs:element name="tokenResponse" type="xp:tokenResponseType" minOccurs="0"/>
+                        <xs:element ref="xp:accountUpdater" minOccurs="0" />
+                        <!-- If Gift Card transaction -->
+                        <xs:element ref="xp:fraudResult" minOccurs="0" />
+                        <xs:element ref="xp:giftCardResponse" minOccurs="0"/>
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="captureGivenAuthResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <!-- if tokenenized merchant -->
+                        <xs:element name="tokenResponse" type="xp:tokenResponseType" minOccurs="0"/>
+                        <!-- If Gift Card transaction -->
+                        <xs:element ref="xp:fraudResult" minOccurs="0" />
+                        <xs:element ref="xp:giftCardResponse" minOccurs="0"/>
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="saleResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="cardProductId" type="xs:string" minOccurs="0" />
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element name="authCode" type="xp:authCodeType" minOccurs="0" />
+                        <xs:element name="authorizationResponseSubCode" type="xs:string" minOccurs="0" />
+                        <xs:element name="approvedAmount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element name="accountInformation" minOccurs="0" type="xp:accountInfoType" />
+                        <xs:element ref="xp:fraudResult" minOccurs="0" />
+                        <!-- if tokenenized merchant -->
+                        <xs:element name="tokenResponse" type="xp:tokenResponseType" minOccurs="0"/>
+                        <xs:element ref="xp:enhancedAuthResponse" minOccurs="0" />
+                        <xs:element ref="xp:accountUpdater" minOccurs="0" />
+                        <xs:element name="recyclingResponse" type="xp:recyclingResponseType" minOccurs="0"/>
+                        <xs:element name="recurringResponse" type="xp:recurringResponseType" minOccurs="0"/>
+                        <!-- If Gift card transaction -->
+                        <xs:element ref="xp:giftCardResponse" minOccurs="0"/>
+                        <xs:element ref="xp:applepayResponse" minOccurs="0"/>
+                        <xs:element name="cardSuffix" type="xp:cardSuffixType" minOccurs="0" />
+                        <xs:element ref="xp:androidpayResponse" minOccurs="0"/>
+                        <!-- If SEPA Direct Debit transaction -->
+                        <xs:element ref="xp:sepaDirectDebitResponse" minOccurs="0"/>
+                        <!-- If iDEAL transaction -->
+                        <xs:element ref="xp:idealResponse" minOccurs="0"/>
+                        <!-- If Giropay transaction -->
+                        <xs:element ref="xp:giropayResponse" minOccurs="0"/>
+                        <!-- If Sofort transaction -->
+                        <xs:element ref="xp:sofortResponse" minOccurs="0"/>
+                        <!-- For merchant initiated transactions -->
+                        <xs:element name="networkTransactionId" type="xp:string30Type" minOccurs="0" />
+                        <!-- If PRIME PINless debit transaction -->
+                        <xs:element ref="xp:pinlessDebitResponse" minOccurs="0"/>
+                        <xs:element name="paymentAccountReferenceNumber" type="xp:string50Type" minOccurs="0" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="creditResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <!-- if tokenenized merchant -->
+                        <xs:element name="tokenResponse" type="xp:tokenResponseType" minOccurs="0"/>
+                        <!-- If Gift Card transaction -->
+                        <xs:element ref="xp:fraudResult" minOccurs="0" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="giftCardCreditResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element ref="xp:fraudResult" minOccurs="0" />
+                        <xs:element ref="xp:giftCardResponse" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="fraudResult">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="avsResult" type="xp:string2Type" minOccurs="0" />
+                <xs:element name="cardValidationResult" type="xs:string" minOccurs="0" />
+                <!-- This is set by Visa and not by MC for 3DS only -->
+                <xs:element name="authenticationResult" type="xp:authenticationResultType" minOccurs="0" />
+                <xs:element name="advancedAVSResult" type="xp:string3Type" minOccurs="0" />
+                <xs:element name="advancedFraudResults" type="xp:advancedFraudResultsType" minOccurs="0"/>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="activateResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element ref="xp:fraudResult" minOccurs="0" />
+                        <xs:element ref="xp:giftCardResponse" />
+                        <xs:element ref="xp:virtualGiftCardResponse" minOccurs="0"/>
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="loadResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element ref="xp:fraudResult" minOccurs="0" />
+                        <xs:element ref="xp:giftCardResponse" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="unloadResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element ref="xp:fraudResult" minOccurs="0" />
+                        <xs:element ref="xp:giftCardResponse" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="giftCardResponse">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="txnTime" type="xs:dateTime" minOccurs="0" />
+                <xs:element name="refCode" type="xp:authCodeType" minOccurs="0" />
+                <xs:element name="systemTraceId" type="xp:systemTraceType" minOccurs="0" />
+                <xs:element name="sequenceNumber" type="xp:sequenceType" minOccurs="0" />
+                <xs:element name="availableBalance" type="xp:string20Type" minOccurs="0"/>
+                <xs:element name="beginningBalance" type="xp:string20Type" minOccurs="0"/>
+                <xs:element name="endingBalance" type="xp:string20Type" minOccurs="0"/>
+                <xs:element name="cashBackAmount" type="xp:string20Type" minOccurs="0"/>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="virtualGiftCardResponse">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="accountNumber" type="xp:ccAccountNumberType" minOccurs="0"/>
+                <xs:element name="pin" type="xp:pinType" minOccurs="0" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="balanceInquiryResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element ref="xp:fraudResult" minOccurs="0" />
+                        <xs:element ref="xp:giftCardResponse" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="deactivateResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element ref="xp:fraudResult" minOccurs="0" />
+                        <xs:element name="approvedAmount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element ref="xp:giftCardResponse" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- echeck -->
+
+    <xs:element name="echeckSale" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                            <xs:element name="amount" type="xp:transactionAmountType" minOccurs="0" />
+                            <xs:element ref="xp:customBilling" minOccurs="0" />
+                            <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                        </xs:sequence>
+                        <xs:sequence>
+                            <xs:element name="orderId" type="xp:string25Type" />
+                            <xs:element name="verify" type="xs:boolean" minOccurs="0" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
+                            <xs:element name="orderSource" type="xp:orderSourceType" />
+                            <xs:element ref="xp:billToAddress" />
+                            <xs:element ref="xp:shipToAddress"  minOccurs="0"/>
+                            <xs:choice><xs:element name="echeck" type="xp:echeckType"/><xs:element name="echeckToken" type="xp:echeckTokenType"/></xs:choice>
+                            <xs:element ref="xp:customBilling" minOccurs="0" />
+                            <xs:element name="merchantData" type="xp:merchantDataType" minOccurs="0" />
+                            <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="echeckCredit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:choice>
+                            <xs:sequence>
+                                <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                                <xs:element name="amount" type="xp:transactionAmountType" minOccurs="0" />
+                                <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
+                                <xs:element ref="xp:customBilling" minOccurs="0" />
+                                <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                            </xs:sequence>
+                            <xs:sequence>
+                                <xs:element name="orderId" type="xp:string25Type" />
+                                <xs:element name="amount" type="xp:transactionAmountType" />
+                                <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
+                                <xs:element name="orderSource" type="xp:orderSourceType" />
+                                <xs:element ref="xp:billToAddress" />
+                                <xs:choice><xs:element name="echeck" type="xp:echeckType"/><xs:element name="echeckToken" type="xp:echeckTokenType"/></xs:choice>
+                                <xs:element ref="xp:customBilling" minOccurs="0" />
+                                <xs:element name="merchantData" type="xp:merchantDataType" minOccurs="0" />
+                                <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                            </xs:sequence>
+                        </xs:choice>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="echeckVerification" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="amount" type="xp:transactionAmountType" /> <!-- required but not tied to sale -->
+                        <xs:element name="orderSource" type="xp:orderSourceType" />
+                        <xs:element ref="xp:billToAddress" minOccurs="1" />  <!-- must supply street, city and state as 2 digit postal state -->
+                        <xs:choice><xs:element name="echeck" type="xp:echeckType"/><xs:element name="echeckToken" type="xp:echeckTokenType"/></xs:choice>
+                        <xs:element name="merchantData" type="xp:merchantDataType" minOccurs="0" />
+                      </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="echeckSalesResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element name="verificationCode" type="xp:authCodeType" minOccurs="0" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element ref="xp:accountUpdater" minOccurs="0" />
+                        <xs:element name="tokenResponse" type="xp:tokenResponseType" minOccurs="0"/>
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="echeckCreditResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element ref="xp:accountUpdater" minOccurs="0" />
+                        <xs:element name="tokenResponse" type="xp:tokenResponseType" minOccurs="0"/>
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="echeckAccountInfoType">
+            <xs:all>
+                <xs:element name="accType" type="xp:echeckAccountTypeEnum" />
+                <xs:element name="accNum" type="xp:echeckAccountNumberType" />
+                <xs:element name="routingNum" type="xp:routingNumberType" />
+            </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="echeckTokenInfoType">
+            <xs:all>
+                <xs:element name="accType" type="xp:echeckAccountTypeEnum" />
+                <xs:element name="cnpToken" type="xp:ccAccountNumberType" />
+                <xs:element name="routingNum" type="xp:routingNumberType" />
+            </xs:all>
+    </xs:complexType>
+
+
+    <xs:complexType name="cardAccountInfoType">
+            <xs:all>
+                <xs:element name="type" type="xp:methodOfPaymentTypeEnum" />
+                <xs:element name="number" type="xp:ccAccountNumberType"/>
+                <xs:element name="expDate" type="xp:expDateType"/>
+            </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="cardTokenInfoType">
+            <xs:all>
+                <xs:element name="cnpToken" type="xp:ccAccountNumberType" />
+                <xs:element name="type" type="xp:methodOfPaymentTypeEnum" />
+                <xs:element name="expDate" type="xp:expDateType" />
+                <xs:element name="bin" type="xs:string" minOccurs="0" />
+            </xs:all>
+    </xs:complexType>
+
+
+    <xs:complexType name="extendedCardResponseType">
+            <xs:all>
+                <xs:element name="message" type="xp:messageType" />
+                <xs:element name="code" type="xp:responseType" />
+            </xs:all>
+    </xs:complexType>
+
+
+    <xs:element name="accountUpdater">
+        <xs:complexType>
+            <xs:choice>
+                <xs:sequence>
+                    <xs:element name="originalAccountInfo" type="xp:echeckAccountInfoType" />
+                    <xs:element name="newAccountInfo" type="xp:echeckAccountInfoType" />
+                </xs:sequence>
+
+                <xs:sequence>
+                    <xs:element name="originalTokenInfo" type="xp:echeckTokenInfoType" />
+                    <xs:element name="newTokenInfo" type="xp:echeckTokenInfoType" />
+                </xs:sequence>
+
+                <xs:sequence>
+                    <xs:element name="originalCardInfo" type="xp:cardAccountInfoType" />
+                    <xs:element name="newCardInfo" type="xp:cardAccountInfoType" />
+                    <xs:element name="extendedCardResponse" type="xp:extendedCardResponseType" minOccurs="0" />
+                    <xs:element name="accountUpdateSource" type="xp:accountUpdateSourceType" minOccurs="0" />
+                </xs:sequence>
+
+                <xs:sequence>
+                    <xs:element name="originalCardTokenInfo" type="xp:cardTokenInfoType" />
+                    <xs:element name="newCardTokenInfo" type="xp:cardTokenInfoType" />
+                    <xs:element name="extendedCardResponse" type="xp:extendedCardResponseType" minOccurs="0" />
+                    <xs:element name="accountUpdateSource" type="xp:accountUpdateSourceType" minOccurs="0" />
+                </xs:sequence>
+
+                <xs:sequence>
+                    <xs:element name="extendedCardResponse" type="xp:extendedCardResponseType" minOccurs="0" />
+                    <xs:element name="accountUpdateSource" type="xp:accountUpdateSourceType" minOccurs="0" />
+                </xs:sequence>
+            </xs:choice>
+
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="echeckVerificationResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <!-- postDate is online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="tokenResponse" type="xp:tokenResponseType" minOccurs="0"/>
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="echeckRedeposit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+	                        <xs:choice minOccurs="0">
+		                        <xs:element name="echeck" type="xp:echeckType"/>
+		                        <xs:element name="echeckToken" type="xp:echeckTokenType"/>
+	                        </xs:choice>
+                        <xs:element name="merchantData" type="xp:merchantDataType" minOccurs="0" />
+                        <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="echeckRedepositResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element ref="xp:accountUpdater" minOccurs="0" />
+                        <xs:element name="tokenResponse" type="xp:tokenResponseType" minOccurs="0"/>
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="echeckType">
+        <xs:all>
+            <xs:element name="accType" type="xp:echeckAccountTypeEnum" />
+            <xs:element name="accNum" type="xp:echeckAccountNumberType" />
+            <xs:element name="routingNum" type="xp:routingNumberType" />
+            <xs:element name="checkNum" type="xp:checkNumberType" minOccurs="0" />
+            <xs:element name="ccdPaymentInformation" type="xp:string80Type" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="echeckTypeCtx">
+        <xs:all>
+            <xs:element name="accType" type="xp:echeckAccountTypeEnum" />
+            <xs:element name="accNum" type="xp:echeckAccountNumberType" />
+            <xs:element name="routingNum" type="xp:routingNumberType" />
+            <xs:element name="checkNum" type="xp:checkNumberType" minOccurs="0" />
+            <xs:element name="ccdPaymentInformation" type="xp:string80Type" minOccurs="0"/>
+            <xs:element name="ctxPaymentInformation" type="xp:ctxPaymentInformationType" minOccurs="0"/>
+        </xs:all>
+     </xs:complexType>
+
+     <xs:complexType name="ctxPaymentInformationType">
+        <xs:sequence>
+                <xs:element name="ctxPaymentDetail" type="xp:string80Type" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="echeckForTokenType">
+        <xs:all>
+            <xs:element name="accNum" type="xp:echeckAccountNumberType" />
+            <xs:element name="routingNum" type="xp:routingNumberType" />
+        </xs:all>
+    </xs:complexType>
+
+    <xs:simpleType name="echeckAccountTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Checking" />
+            <xs:enumeration value="Savings" />
+            <xs:enumeration value="Corporate" />
+            <xs:enumeration value="Corp Savings" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="echeckAccountNumberType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="17" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="routingNumberType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="8" />
+            <xs:maxLength value="9" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="checkNumberType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1" />
+            <xs:maxLength value="15" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- This is for secure, we need a value to indicate that CAVV was attempted but unavailable -->
+    <xs:simpleType name="authenticationValueType">
+        <xs:restriction base="xs:base64Binary">
+            <xs:maxLength value="56" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="authenticationTransactionIdType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="36" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="reportGroupType">
+        <xs:restriction base="xs:string">
+            <xs:whiteSpace value="collapse" />
+            <xs:minLength value="1" />
+            <xs:maxLength value="25" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="authenticationProtocolVersionType">
+        <xs:restriction base="xs:integer">
+            <xs:enumeration value="1" />
+            <xs:enumeration value="2" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="orderSourceType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ecommerce" />
+            <xs:enumeration value="installment" />
+            <xs:enumeration value="mailorder" />
+            <xs:enumeration value="recurring" />
+            <xs:enumeration value="retail" />
+            <xs:enumeration value="telephone" />
+            <xs:enumeration value="3dsAuthenticated" />
+            <xs:enumeration value="3dsAttempted" />
+            <!-- recurringtel is only for echeck -->
+            <xs:enumeration value="recurringtel" />
+            <!-- echeckppd is only for echeck sale transaction -->
+            <xs:enumeration value="echeckppd" />
+            <xs:enumeration value="applepay" />
+            <xs:enumeration value="androidpay" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="posCapabilityTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="notused" />
+            <xs:enumeration value="magstripe" />
+            <xs:enumeration value="keyedonly" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="posEntryModeTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="notused" />
+            <xs:enumeration value="keyed" />
+            <xs:enumeration value="track1" />
+            <xs:enumeration value="track2" />
+            <xs:enumeration value="completeread" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="posCardholderIdTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="signature" />
+            <xs:enumeration value="pin" />
+            <xs:enumeration value="nopin" />
+            <xs:enumeration value="directmarket" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="posCatLevelEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="self service" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="descriptorType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="4" />
+            <xs:maxLength value="25" />
+            <xs:pattern value="[A-Z,a-z,0-9, ,\*,,,\-,',#,&amp;,.]*" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="customBillingPhoneType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="13" />
+            <xs:pattern value="[0-9]*" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="customerReferenceType">
+        <xs:restriction base="xs:string">
+            <xs:whiteSpace value="collapse" />
+            <xs:minLength value="1" />
+            <xs:maxLength value="17" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="invoiceReferenceNumberType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1" />
+            <xs:maxLength value="15" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cardAcceptorTaxIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1" />
+            <xs:maxLength value="20" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="taxRateType">
+        <xs:restriction base="xs:decimal">
+            <xs:totalDigits value="5" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="itemSequenceNumberType">
+        <xs:restriction base="xs:integer">
+            <xs:minInclusive value="1" />
+            <xs:maxInclusive value="99" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="itemDescriptionType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1" />
+            <xs:maxLength value="26" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="productCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1" />
+            <xs:maxLength value="12" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="commodityCodeType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1" />
+            <xs:maxLength value="12" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="quantityType">
+        <xs:restriction base="xs:decimal">
+            <xs:minInclusive value="0" />
+            <xs:totalDigits value="12" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="unitOfMeasureType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1" />
+            <xs:maxLength value="12" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="unitCostType">
+        <xs:restriction base="xs:decimal">
+            <xs:minInclusive value="0" />
+            <xs:totalDigits value="12" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="ipAddress">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="(\d{1,3}.){3}\d{1,3}" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="filteringType">
+        <xs:sequence>
+            <xs:element name="prepaid" type="xs:boolean" minOccurs="0"/>
+            <xs:element name="international" type="xs:boolean" minOccurs="0"/>
+            <xs:element name="chargeback" type="xs:boolean" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="campaignType">
+        <xs:restriction base="xs:string">
+            <xs:whiteSpace value="collapse" />
+            <xs:minLength value="1" />
+            <xs:maxLength value="25" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="affiliateType">
+        <xs:restriction base="xs:string">
+            <xs:whiteSpace value="collapse" />
+            <xs:minLength value="1" />
+            <xs:maxLength value="25" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="merchantGroupingIdType">
+        <xs:restriction base="xs:string">
+            <xs:whiteSpace value="collapse" />
+            <xs:minLength value="1" />
+            <xs:maxLength value="25" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="updateCardValidationNumOnToken" substitutionGroup="xp:transaction" type="xp:updateCardValidationNumOnToken"/>
+
+    <xs:complexType name="updateCardValidationNumOnToken">
+        <xs:complexContent>
+            <xs:extension base="xp:transactionTypeWithReportGroup">
+                <xs:sequence>
+                    <xs:element name="orderId" type="xp:string25Type" minOccurs="0" />
+                    <xs:element name="cnpToken" type="xp:ccAccountNumberType" />
+                    <xs:element name="cardValidationNum" type="xp:cvNumType"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:element name="updateCardValidationNumOnTokenResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="message" type="xs:string"/>
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="virtualGiftCardType">
+        <xs:sequence>
+                    <xs:element name="accountNumberLength" type="xs:integer"/>
+                    <xs:element name="giftCardBin" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="fraudCheck" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:element name="advancedFraudChecks" type="xp:advancedFraudChecksType" minOccurs="0"/>
+                        <xs:element ref="xp:billToAddress" minOccurs="0" />
+                        <xs:element ref="xp:shipToAddress" minOccurs="0" />
+                        <xs:element name="amount" type="xp:transactionAmountType" minOccurs="0" />
+                        <xs:element name="eventType" minOccurs="0">
+                          <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                              <xs:enumeration value="payment"/>
+                              <xs:enumeration value="login"/>
+                              <xs:enumeration value="account_creation"/>
+                              <xs:enumeration value="details_change"/>
+                            </xs:restriction>
+                          </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="accountLogin" minOccurs="0">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:maxLength value="255"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="accountPasshash" minOccurs="0">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:pattern value="[a-fA-F0-9]{128}|[a-fA-F0-9]{96}|[a-fA-F0-9]{64}|[a-fA-F0-9]{56}"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="fraudCheckResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="message" type="xs:string"/>
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="advancedFraudResults" type="xp:advancedFraudResultsType" minOccurs="0"/>
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="walletSourceType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="MasterPass" />
+            <xs:enumeration value="VisaCheckout" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="wallet">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="walletSourceType" type="xp:walletSourceType" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="walletSourceTypeId" type="xs:string" minOccurs="1" maxOccurs="1" />
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="applepayType">
+        <xs:sequence>
+            <xs:element name="data">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="2000"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="header" type="xp:applepayHeaderType" />
+            <xs:element name="signature">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="10000"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="version">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:minLength value="5"/>
+                        <xs:maxLength value="10"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="applepayHeaderType">
+        <xs:sequence>
+            <xs:element name="applicationData" minOccurs="0" maxOccurs="1" >
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="10000"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="ephemeralPublicKey">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="400"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="publicKeyHash">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="200"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="transactionId">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="250"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="applepayResponse">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="applicationPrimaryAccountNumber" type="xp:string20Type" minOccurs="0"/>
+                <xs:element name="applicationExpirationDate" type="xp:string20Type" minOccurs="0"/>
+                <xs:element name="currencyCode" type="xp:string3Type" minOccurs="0"/>
+                <xs:element name="transactionAmount" type="xp:transactionAmountType" minOccurs="0"/>
+                <xs:element name="cardholderName" type="xp:string512Type" minOccurs="0"/>
+                <xs:element name="deviceManufacturerIdentifier" type="xp:string20Type" minOccurs="0"/>
+                <xs:element name="paymentDataType" type="xp:string20Type" minOccurs="0"/>
+                <xs:element name="onlinePaymentCryptogram" type="xp:authenticationValueType" minOccurs="0"/>
+                <xs:element name="eciIndicator" type="xp:string2Type" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="androidpayResponse">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="cryptogram" type="xp:authenticationValueType" minOccurs="0"/>
+                <xs:element name="expMonth" type="xp:string2Type" minOccurs="0"/>
+                <xs:element name="expYear" type="xp:string4Type" minOccurs="0"/>
+                <xs:element name="eciIndicator" type="xp:string2Type" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="processingTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="accountFunding" />
+            <xs:enumeration value="initialRecurring" />
+            <xs:enumeration value="initialInstallment" />
+            <xs:enumeration value="initialCOF" />
+            <xs:enumeration value="merchantInitiatedCOF" />
+            <xs:enumeration value="cardholderInitiatedCOF" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="sepaDirectDebitType">
+        <xs:sequence>
+            <xs:element name="mandateProvider"  maxOccurs="1">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="Merchant" />
+                        <xs:enumeration value="Vantiv" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="sequenceType" maxOccurs="1">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="OneTime" />
+                        <xs:enumeration value="FirstRecurring" />
+                        <xs:enumeration value="SubsequentRecurring" />
+                        <xs:enumeration value="FinalRecurring" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="mandateReference" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:minLength value="1"/>
+                        <xs:maxLength value="256"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="mandateUrl" minOccurs="0" >
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:minLength value="1"/>
+                        <xs:maxLength value="2000"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="mandateSignatureDate" type="xs:date" minOccurs="0" />
+            <xs:element name="iban">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:minLength value="15" />
+                        <xs:maxLength value="34" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="preferredLanguage" type="xp:countryTypeEnum" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="sepaDirectDebitResponse">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="redirectUrl" type="xp:string256Type" minOccurs="0" />
+                <xs:element name="redirectToken" type="xp:string128Type" minOccurs="0" />
+                <xs:element name="mandateReference" type="xp:string256Type" minOccurs="0" />
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="idealType">
+        <xs:all>
+            <xs:element name="preferredLanguage" type="xp:countryTypeEnum" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:element name="idealResponse">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="redirectUrl" type="xp:string256Type" minOccurs="0"/>
+                <xs:element name="redirectToken" type="xp:string128Type" minOccurs="0"/>
+                <xs:element name="paymentPurpose" type="xp:string256Type" minOccurs="0"/>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+        <xs:complexType name="giropayType">
+        <xs:all>
+            <xs:element name="preferredLanguage" type="xp:countryTypeEnum" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:element name="giropayResponse">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="redirectUrl" type="xp:string256Type" minOccurs="0"/>
+                <xs:element name="redirectToken" type="xp:string128Type" minOccurs="0"/>
+                <xs:element name="paymentPurpose" type="xp:string256Type" minOccurs="0"/>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+        <xs:complexType name="sofortType">
+        <xs:all>
+            <xs:element name="preferredLanguage" type="xp:countryTypeEnum" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:element name="sofortResponse">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="redirectUrl" type="xp:string256Type" minOccurs="0"/>
+                <xs:element name="redirectToken" type="xp:string128Type" minOccurs="0"/>
+                <xs:element name="paymentPurpose" type="xp:string256Type" minOccurs="0"/>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="systemTraceType">
+        <xs:restriction base="xs:int">
+            <xs:totalDigits value="6"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="sequenceType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{6}|0"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+
+    <xs:element name="submerchantCreditResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="submerchantDebitResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="payFacDebit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="payFacCredit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="payFacCreditResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="payFacDebitResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="reserveCredit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:choice>
+                                <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                                <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            </xs:choice>
+                            <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="reserveDebit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:choice>
+                                <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                                <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            </xs:choice>
+                            <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="reserveCreditResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="reserveDebitResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="physicalCheckCredit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:choice>
+                                <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                                <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            </xs:choice>
+                            <xs:element name="fundsTransferId" type="xp:string36Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="physicalCheckCreditResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="physicalCheckDebit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:choice>
+                                <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                                <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            </xs:choice>
+                            <xs:element name="fundsTransferId" type="xp:string36Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="physicalCheckDebitResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+
+    <xs:element name="vendorDebitResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="vendorCreditResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="fundingInstructionVoid" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="fundingInstructionVoidResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="pinlessDebitResponse">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="networkName" type="xp:string25Type" minOccurs="0" />
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="routingPreferenceEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="pinlessDebitOnly" />
+            <xs:enumeration value="signatureOnly" />
+            <xs:enumeration value="regular" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="fastAccessFunding" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:choice>
+                                <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                                <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            </xs:choice>
+                            <xs:choice>
+                                <xs:element name="customerName" type="xp:string256Type"/>
+                                <xs:element name="submerchantName" type="xp:string256Type"/>
+                            </xs:choice>
+                            <xs:element name="fundsTransferId" type="xp:stringExactly16AlphanumericType" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="disbursementType" type="xp:disbursementTypeEnum" minOccurs="0"/>
+                            <xs:choice>
+                                <xs:element name="card" type="xp:cardType" />
+                                <xs:element name="token" type="xp:cardTokenType" />
+                                <xs:element name="paypage" type="xp:cardPaypageType" />
+                            </xs:choice>
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="fastAccessFundingResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:stringExactly16AlphanumericType"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <!-- if tokenized merchant -->
+                        <xs:element name="tokenResponse" type="xp:tokenResponseType" minOccurs="0"/>
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="customerCreditResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="customerDebitResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="payoutOrgDebit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                            <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="payoutOrgCredit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                            <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="payoutOrgCreditResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="payoutOrgDebitResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="fundsTransferId" type="xp:string36Type"/>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <!-- online only -->
+                        <xs:element name="postDate" type="xs:date" minOccurs="0" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                    <xs:attribute name="duplicate" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="translateToLowValueTokenRequest" substitutionGroup="xp:transaction" type="xp:translateToLowValueTokenRequestType"/>
+
+	<xs:complexType name="translateToLowValueTokenRequestType">
+	    <xs:complexContent>
+	        <xs:extension base="xp:transactionTypeWithReportGroup">
+	            <xs:sequence>
+	                <xs:element name="orderId" type="xp:string25Type" minOccurs="0" />
+	                <xs:element name="token" type="xp:string512Type" minOccurs="1" />
+	            </xs:sequence>
+	        </xs:extension>
+	     </xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="translateToLowValueTokenResponse" substitutionGroup="xp:transactionResponse">
+	    <xs:complexType>
+	        <xs:complexContent>
+	            <xs:extension base="xp:transactionTypeWithReportGroup">
+	                <xs:all>
+                        <xs:element name="orderId" type="xp:string25Type" minOccurs="0" />
+	                    <xs:element name="paypageRegistrationId" type="xp:string512Type"  minOccurs="0" />
+	                    <xs:element name="response" type="xp:responseType" />
+	                    <xs:element name="message" type="xs:string"/>
+	                    <xs:element name="responseTime" type="xs:dateTime" />
+	                </xs:all>
+	            </xs:extension>
+	        </xs:complexContent>
+	    </xs:complexType>
+	</xs:element>
+
+    <xs:complexType name="pinlessDebitRequestType">
+        <xs:sequence>
+                <xs:element name="routingPreference" type="xp:routingPreferenceEnum" minOccurs="0" />
+                <xs:element name="preferredDebitNetworks" type="xp:preferredDebitNetworksType" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="preferredDebitNetworksType">
+        <xs:sequence>
+                <xs:element name="debitNetworkName" type="xp:string25Type" minOccurs="1" maxOccurs="12"/>
+        </xs:sequence>
+    </xs:complexType>
+
+ <xs:element name="lodgingInfo">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="hotelFolioNumber" type="xp:string25Type" minOccurs="0" />
+                <xs:element name="checkInDate" type="xs:date" minOccurs="0" />
+                <xs:element name="checkOutDate" type="xs:date" minOccurs="0" />
+                <xs:element name="duration" type="xp:lodgingDurationType" minOccurs="0" />
+                <xs:element name="customerServicePhone" type="xp:csPhoneType" minOccurs="0" />
+                <xs:element name="programCode" minOccurs="0" type="xp:lodgingProgramCodeType" default="LODGING" />
+                <xs:element name="roomRate" type="xp:transactionAmountType" minOccurs="0" />
+                <xs:element name="roomTax" type="xp:transactionAmountType" minOccurs="0" />
+                <xs:element name="numAdults" type="xp:noOfAdultsType" minOccurs="0" />
+                <xs:element name="propertyLocalPhone" type="xp:csPhoneType" minOccurs="0" />
+                <xs:element name="fireSafetyIndicator" type="xs:boolean" minOccurs="0" />
+                <xs:element ref="xp:lodgingCharge" minOccurs="0" maxOccurs="6"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="disbursementTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="VAA" />
+            <xs:enumeration value="VBB" />
+            <xs:enumeration value="VBI" />
+            <xs:enumeration value="VBP" />
+            <xs:enumeration value="VCC" />
+            <xs:enumeration value="VCI" />
+            <xs:enumeration value="VCO" />
+            <xs:enumeration value="VCP" />
+            <xs:enumeration value="VFD" />
+            <xs:enumeration value="VGD" />
+            <xs:enumeration value="VGP" />
+            <xs:enumeration value="VLO" />
+            <xs:enumeration value="VMA" />
+            <xs:enumeration value="VMD" />
+            <xs:enumeration value="VMI" />
+            <xs:enumeration value="VMP" />
+            <xs:enumeration value="VOG" />
+            <xs:enumeration value="VPD" />
+            <xs:enumeration value="VPG" />
+            <xs:enumeration value="VPP" />
+            <xs:enumeration value="VPS" />
+            <xs:enumeration value="VTU" />
+            <xs:enumeration value="VWT" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!--cnpBatch-->
+    <xs:element name="cnpRequest">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="xp:authentication" />
+                <xs:choice>
+                    <xs:element ref="xp:batchRequest" minOccurs="0" maxOccurs="unbounded" />
+                    <xs:element ref="xp:RFRRequest" minOccurs="0" />
+                </xs:choice>
+            </xs:sequence>
+            <xs:attribute name="version" type="xp:versionType" use="required" />
+            <xs:attribute name="id" type="xp:string25Type" use="optional" />
+            <xs:attribute name="numBatchRequests" type="xs:integer" use="required" />
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="RFRRequest">
+        <xs:complexType>
+            <xs:choice>
+                <xs:element name="cnpSessionId" type="xp:cnpIdType" />
+                <xs:element ref="xp:accountUpdateFileRequestData" />
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="batchRequest">
+        <xs:complexType>
+            <xs:choice>
+                <xs:element ref="xp:transaction" maxOccurs="unbounded" />
+                <xs:element ref="xp:recurringTransaction" maxOccurs="unbounded" />
+            </xs:choice>
+                        <xs:attribute name="merchantSdk" type="xs:string" use="optional" />
+            <xs:attribute name="id" type="xp:string25Type" use="optional" />
+            <xs:attribute name="numAuths" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="authAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numAuthReversals" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="authReversalAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numGiftCardAuthReversals" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="giftCardAuthReversalOriginalAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numCaptures" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="captureAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numGiftCardCaptures" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="giftCardCaptureAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numExtCaptures" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="extCaptureAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numCredits" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="creditAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numGiftCardCredits" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="giftCardCreditAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numForceCaptures" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="forceCaptureAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numSales" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="saleAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numCaptureGivenAuths" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="captureGivenAuthAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numEcheckSales" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="echeckSalesAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numEcheckCredit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="echeckCreditAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numEcheckVerification" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="echeckVerificationAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numEcheckRedeposit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numEcheckPreNoteSale" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numEcheckPreNoteCredit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numAccountUpdates" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numTokenRegistrations" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numUpdateCardValidationNumOnTokens" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numCancelSubscriptions" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numUpdateSubscriptions" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numCreatePlans" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numUpdatePlans" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numActivates" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numDeactivates" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="activateAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numLoads" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="loadAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numUnloads" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="unloadAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="numBalanceInquirys" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numPayFacCredit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numPayFacDebit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numSubmerchantCredit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numSubmerchantDebit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numReserveCredit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numReserveDebit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numVendorDebit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numVendorCredit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numPhysicalCheckDebit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numPhysicalCheckCredit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numFundingInstructionVoid" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numFastAccessFunding" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numPayoutOrgCredit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numPayoutOrgDebit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numCustomerCredit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numCustomerDebit" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="numTranslateToLowValueTokenRequests" type="xs:integer" use="optional"  default="0"/>
+            <xs:attribute name="payFacCreditAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="payFacDebitAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="submerchantCreditAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="submerchantDebitAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="reserveCreditAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="reserveDebitAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="vendorDebitAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="vendorCreditAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="physicalCheckDebitAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="physicalCheckCreditAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="fastAccessFundingAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="payoutOrgCreditAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="payoutOrgDebitAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="customerCreditAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="customerDebitAmount" type="xp:batchTotalAmountType" use="optional"  default="0"/>
+            <xs:attribute name="sameDayFunding" type="xs:boolean" use="optional"  default="0"/>
+            <xs:attribute name="merchantId" type="xp:merchantIdentificationType" use="required" />
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="cardOrToken" abstract="true"/>
+    <xs:element name="card" substitutionGroup="xp:cardOrToken" type="xp:cardType"/>
+    <xs:element name="token" substitutionGroup="xp:cardOrToken" type="xp:cardTokenType"/>
+
+
+    <xs:element name="accountUpdate" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element ref="xp:cardOrToken" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="cnpResponse">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:choice>
+                    <xs:element ref="xp:batchResponse" minOccurs="0" maxOccurs="unbounded" />
+                    <xs:element ref="xp:RFRResponse" />
+                </xs:choice>
+            </xs:sequence>
+            <xs:attribute name="version" type="xp:versionType" use="required" />
+            <xs:attribute name="id" type="xp:string25Type" use="optional" />
+            <xs:attribute name="response" type="xp:responseType" use="required" />
+            <xs:attribute name="message" type="xp:messageType" use="required" />
+            <xs:attribute name="cnpSessionId" type="xp:cnpIdType" use="required" />
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="RFRResponse">
+        <xs:complexType>
+            <xs:attribute name="response" type="xp:responseType" use="required" />
+            <xs:attribute name="message" type="xp:messageType" use="required" />
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="batchResponse">
+        <xs:complexType>
+            <xs:choice>
+                <xs:element ref="xp:transactionResponse" minOccurs="0" maxOccurs="unbounded" />
+                <xs:element ref="xp:recurringTransactionResponse" minOccurs="0" maxOccurs="unbounded" />
+            </xs:choice>
+            <xs:attribute name="id" type="xp:string25Type" />
+            <xs:attribute name="cnpBatchId" type="xp:cnpIdType" use="required" />
+            <xs:attribute name="merchantId" type="xp:merchantIdentificationType" use="required" />
+            <xs:attribute name="numAccountUpdates" type="xs:integer" use="optional"  default="0"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="accountUpdateResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element name="updatedCard" type="xp:cardType" minOccurs="0" />
+                        <xs:element name="originalCard" type="xp:cardType" minOccurs="0" />
+                        <xs:element name="updatedToken" type="xp:cardTokenTypeAU" minOccurs="0" />
+                        <xs:element name="originalToken" type="xp:cardTokenTypeAU" minOccurs="0" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="cardTokenTypeAU">
+        <xs:complexContent>
+            <xs:extension base="xp:cardTokenType">
+                <xs:sequence>
+                    <xs:element name="bin" type="xs:string" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:simpleType name="batchTotalAmountType">
+        <xs:restriction base="xs:integer">
+            <xs:totalDigits value="10" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="template">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="25" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="accountUpdateFileRequestData">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="merchantId" type="xp:merchantIdentificationType" />
+                <xs:element name="postDay" type="xs:date" minOccurs="0" />
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="echeckPreNoteSale" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderSource" type="xp:orderSourceType" />
+                        <xs:element ref="xp:billToAddress" />
+                        <xs:element name="echeck" type="xp:echeckType"/>
+                        <xs:element name="merchantData" type="xp:merchantDataType" minOccurs="0" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="echeckPreNoteCredit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderSource" type="xp:orderSourceType" />
+                        <xs:element ref="xp:billToAddress" />
+                        <xs:element name="echeck" type="xp:echeckType"/>
+                        <xs:element name="merchantData" type="xp:merchantDataType" minOccurs="0" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="echeckPreNoteSaleResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="echeckPreNoteCreditResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+     <xs:element name="vendorCredit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:choice>
+                                <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                                <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            </xs:choice>
+                            <xs:element name="vendorName" type="xp:string256Type"/>
+                            <xs:element name="fundsTransferId" type="xp:string36Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="accountInfo" type="xp:echeckTypeCtx" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="vendorDebit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:choice>
+                                <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                                <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            </xs:choice>
+                            <xs:element name="vendorName" type="xp:string256Type"/>
+                            <xs:element name="fundsTransferId" type="xp:string36Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="accountInfo" type="xp:echeckTypeCtx" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+
+    <xs:element name="submerchantCredit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            <xs:element name="submerchantName" type="xp:string256Type"/>
+                            <xs:element name="fundsTransferId" type="xp:string36Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="accountInfo" type="xp:echeckTypeCtx" />
+                            <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="submerchantDebit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            <xs:element name="submerchantName" type="xp:string256Type"/>
+                            <xs:element name="fundsTransferId" type="xp:string36Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="accountInfo" type="xp:echeckTypeCtx" />
+                            <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="customerCredit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                            <xs:element name="customerName" type="xp:string256Type"/>
+                            <xs:element name="fundsTransferId" type="xp:string36Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="accountInfo" type="xp:echeckTypeCtx" />
+                            <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="customerDebit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                            <xs:element name="customerName" type="xp:string256Type"/>
+                            <xs:element name="fundsTransferId" type="xp:string36Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="accountInfo" type="xp:echeckTypeCtx" />
+                            <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <!--cnpOnline-->
+    <xs:complexType name="baseRequest">
+        <xs:sequence>
+            <xs:element ref="xp:authentication" />
+            <xs:choice>
+                <xs:element ref="xp:transaction" />
+                <xs:element ref="xp:recurringTransaction" />
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="version" type="xp:versionType" use="required" />
+    </xs:complexType>
+
+    <xs:element name="cnpOnlineRequest">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:baseRequest">
+                    <xs:attribute name="merchantId" type="xp:merchantIdentificationType" use="required" />
+                    <xs:attribute name="merchantSdk" type="xs:string" use="optional" />
+                    <xs:attribute name="loggedInUser" type="xs:string" use="optional"/>
+                    <xs:attribute name="sameDayFunding" type="xs:boolean" use="optional" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="cnpOnlineResponse">
+        <xs:complexType>
+            <xs:choice>
+                <xs:element ref="xp:transactionResponse" minOccurs="0" />
+                <xs:element ref="xp:recurringTransactionResponse" minOccurs="0" />
+            </xs:choice>
+            <xs:attribute name="response" type="xp:responseType" use="required" />
+            <xs:attribute name="message" type="xp:messageType" use="required" />
+            <xs:attribute name="version" type="xp:versionType" use="required" />
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="void" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element ref="xp:processingInstructions" minOccurs="0" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="voidResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="postDate" type="xs:date" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element name="recyclingResponse" type="xp:voidRecyclingResponseType" minOccurs="0" />
+                    </xs:all>
+
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="voidRecyclingResponseType">
+        <xs:sequence>
+            <xs:element name="creditCnpTxnId" type="xp:cnpIdType" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="echeckVoid" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="echeckVoidResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="postDate" type="xs:date" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="depositReversal" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" minOccurs="0" />
+                        <xs:element name="card" type="xp:giftCardCardType" />
+                        <xs:element name="originalRefCode" type="xp:authCodeType" />
+                        <xs:element name="originalAmount" type="xp:transactionAmountType" />
+                        <xs:element name="originalTxnTime" type="xs:dateTime" />
+                        <xs:element name="originalSystemTraceId" type="xp:systemTraceType" />
+                        <xs:element name="originalSequenceNumber" type="xp:sequenceType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="refundReversal" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" minOccurs="0" />
+                        <xs:element name="card" type="xp:giftCardCardType" />
+                        <xs:element name="originalRefCode" type="xp:authCodeType" />
+                        <xs:element name="originalAmount" type="xp:transactionAmountType" />
+                        <xs:element name="originalTxnTime" type="xs:dateTime" />
+                        <xs:element name="originalSystemTraceId" type="xp:systemTraceType" />
+                        <xs:element name="originalSequenceNumber" type="xp:sequenceType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="activateReversal" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" minOccurs="0" />
+                        <xs:element name="card" type="xp:giftCardCardType" />
+                        <xs:element name="virtualGiftCardBin" type="xs:string" minOccurs="0"/>
+                        <xs:element name="originalRefCode" type="xp:authCodeType" />
+                        <xs:element name="originalAmount" type="xp:transactionAmountType" />
+                        <xs:element name="originalTxnTime" type="xs:dateTime" />
+                        <xs:element name="originalSystemTraceId" type="xp:systemTraceType" />
+                        <xs:element name="originalSequenceNumber" type="xp:sequenceType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="deactivateReversal" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" minOccurs="0" />
+                        <xs:element name="card" type="xp:giftCardCardType" />
+                        <xs:element name="originalRefCode" type="xp:authCodeType" />
+                        <xs:element name="originalTxnTime" type="xs:dateTime" />
+                        <xs:element name="originalSystemTraceId" type="xp:systemTraceType" />
+                        <xs:element name="originalSequenceNumber" type="xp:sequenceType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="loadReversal" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" minOccurs="0" />
+                        <xs:element name="card" type="xp:giftCardCardType" />
+                        <xs:element name="originalRefCode" type="xp:authCodeType" />
+                        <xs:element name="originalAmount" type="xp:transactionAmountType" />
+                        <xs:element name="originalTxnTime" type="xs:dateTime" />
+                        <xs:element name="originalSystemTraceId" type="xp:systemTraceType" />
+                        <xs:element name="originalSequenceNumber" type="xp:sequenceType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="unloadReversal" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" minOccurs="0" />
+                        <xs:element name="card" type="xp:giftCardCardType" />
+                        <xs:element name="originalRefCode" type="xp:authCodeType" />
+                        <xs:element name="originalAmount" type="xp:transactionAmountType" />
+                        <xs:element name="originalTxnTime" type="xs:dateTime" />
+                        <xs:element name="originalSystemTraceId" type="xp:systemTraceType" />
+                        <xs:element name="originalSequenceNumber" type="xp:sequenceType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="queryTransaction" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:sequence>
+                        <xs:element name="origId" type="xp:string25Type" minOccurs="0" />
+                        <xs:element name="origActionType" type="xp:actionTypeEnum" minOccurs="0" />
+                        <xs:element name="origCnpTxnId" type="xp:cnpIdType" minOccurs="0" />
+                        <xs:element name="showStatusOnly" type="xp:yesNoType" minOccurs="0" />
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="queryTransactionResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="message" type="xp:messageType" />
+                        <xs:element name="matchCount" minOccurs="0">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:int">
+                                    <xs:totalDigits value="4" />
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="results_max10" minOccurs="0">
+                            <xs:complexType>
+                                <xs:choice>
+                                    <xs:element ref="xp:transactionResponse" minOccurs="0" maxOccurs="10" />
+                                </xs:choice>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="queryTransactionUnavailableResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="message" type="xp:messageType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="serviceStatusRequest" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="serviceId" type="xp:cnpIdType" />
+                        <xs:element name="pathId" type="xp:cnpIdType" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="serviceStatusResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" />
+                        <xs:element name="response" type="xp:responseType" />
+                        <xs:element name="responseTime" type="xs:dateTime" />
+                        <xs:element name="message" type="xs:string"/>
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
Purpose
======
The purpose of this pull request is to do a mock upgrade on the CNP SDK OmniVersion concept generator from 12.10 to 12.11.

Changes
======
* Added the 12.11 XSD file.
* Added special case for converting `echeckTypeCtx` to `echeckType`
  * In 12.11, `vendorCredit`, `vendorDebit`, `submerchantCredit`, `submerchantDebit`, `customerCredit`, and `customerDebit` were changed to use `echeckTypeCtx` instead of `echeckType`, which causes compiler errors with old versions since the expected class changed. To solve this, the base class of `echeckTypeCtx` was overridden from nothing to `echeckType` and the 6 classes were changed to have `accountInfo` use `echeckType` instead of `echeckTypeCtx`, which can be replaced by a 12.11 user since it is a subclass.